### PR TITLE
feat(routing): wire Valhalla, Google Routes, and MultiRouteService

### DIFF
--- a/lib/bridge/frb_generated.dart
+++ b/lib/bridge/frb_generated.dart
@@ -65,7 +65,7 @@ class RustBridge
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1818867158;
+  int get rustContentHash => 47569698;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -168,7 +168,10 @@ abstract class RustBridgeApi extends BaseApi {
 
   String crateImportRouteFromGpx({required List<int> bytes});
 
-  Future<void> crateInitializeDatabase({required String dbPath});
+  Future<void> crateInitializeDatabase({
+    required String dbPath,
+    String? googleRoutesApiKey,
+  });
 
   String crateParseRouteFromGpx({required List<int> bytes});
 
@@ -240,6 +243,8 @@ abstract class RustBridgeApi extends BaseApi {
     required PlatformInt64 deviceId,
     required String routeJson,
   });
+
+  Future<void> crateSetRoutingEngine({required String engine});
 
   Future<String> crateStartNavigationSession({
     required List<(double, double)> waypoints,
@@ -1107,12 +1112,16 @@ class RustBridgeApiImpl extends RustBridgeApiImplPlatform
   );
 
   @override
-  Future<void> crateInitializeDatabase({required String dbPath}) {
+  Future<void> crateInitializeDatabase({
+    required String dbPath,
+    String? googleRoutesApiKey,
+  }) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
+          sse_encode_opt_String(googleRoutesApiKey, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1125,7 +1134,7 @@ class RustBridgeApiImpl extends RustBridgeApiImplPlatform
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateInitializeDatabaseConstMeta,
-        argValues: [dbPath],
+        argValues: [dbPath, googleRoutesApiKey],
         apiImpl: this,
       ),
     );
@@ -1133,7 +1142,7 @@ class RustBridgeApiImpl extends RustBridgeApiImplPlatform
 
   TaskConstMeta get kCrateInitializeDatabaseConstMeta => const TaskConstMeta(
     debugName: "initialize_database",
-    argNames: ["dbPath"],
+    argNames: ["dbPath", "googleRoutesApiKey"],
   );
 
   @override
@@ -1623,6 +1632,36 @@ class RustBridgeApiImpl extends RustBridgeApiImplPlatform
   );
 
   @override
+  Future<void> crateSetRoutingEngine({required String engine}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(engine, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 48,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateSetRoutingEngineConstMeta,
+        argValues: [engine],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateSetRoutingEngineConstMeta => const TaskConstMeta(
+    debugName: "set_routing_engine",
+    argNames: ["engine"],
+  );
+
+  @override
   Future<String> crateStartNavigationSession({
     required List<(double, double)> waypoints,
     required (double, double) currentPosition,
@@ -1636,7 +1675,7 @@ class RustBridgeApiImpl extends RustBridgeApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -1667,7 +1706,7 @@ class RustBridgeApiImpl extends RustBridgeApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -1698,7 +1737,7 @@ class RustBridgeApiImpl extends RustBridgeApiImplPlatform
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_i_64(id, serializer);
           sse_encode_String(deviceJson, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1732,7 +1771,7 @@ class RustBridgeApiImpl extends RustBridgeApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },

--- a/lib/bridge/lib.dart
+++ b/lib/bridge/lib.dart
@@ -6,11 +6,25 @@
 import 'frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-/// Initialize the database with the platform-specific path.
-/// Constructs OSRM routing and Nominatim geocoding services and injects them into nav_core.
-/// Must be called before any database operations.
-Future<void> initializeDatabase({required String dbPath}) =>
-    RustBridge.instance.api.crateInitializeDatabase(dbPath: dbPath);
+/// Initialize the database and routing engines.
+///
+/// Always registers OSRM (public) and Valhalla (public openstreetmap.de instance).
+/// Pass `google_routes_api_key` to also enable Google Routes — obtain a key via
+/// `--dart-define=GOOGLE_ROUTES_KEY=...` at build time.
+///
+/// Must be called before any other API functions.
+Future<void> initializeDatabase({
+  required String dbPath,
+  String? googleRoutesApiKey,
+}) => RustBridge.instance.api.crateInitializeDatabase(
+  dbPath: dbPath,
+  googleRoutesApiKey: googleRoutesApiKey,
+);
+
+/// Switch the active routing engine. Valid names: `"osrm"`, `"valhalla"`, `"googleRoutes"`.
+/// Google Routes is only available if an API key was provided to `initialize_database`.
+Future<void> setRoutingEngine({required String engine}) =>
+    RustBridge.instance.api.crateSetRoutingEngine(engine: engine);
 
 /// Calculate a route between waypoints
 Future<String> calculateRoute({required List<(double, double)> waypoints}) =>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,7 +97,11 @@ class _AppLoaderState extends State<_AppLoader> {
     final appDir = await getApplicationDocumentsDirectory();
     final dbPath = path.join(appDir.path, 'nav_e.db');
     debugPrint('[main] Initializing database at $dbPath...');
-    await rust_api.initializeDatabase(dbPath: dbPath);
+    const googleRoutesKey = String.fromEnvironment('GOOGLE_ROUTES_KEY');
+    await rust_api.initializeDatabase(
+      dbPath: dbPath,
+      googleRoutesApiKey: googleRoutesKey.isEmpty ? null : googleRoutesKey,
+    );
     debugPrint('[main] Database ready.');
 
     await NavNotificationService.instance.init();

--- a/native/nav_e_ffi/Cargo.toml
+++ b/native/nav_e_ffi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 nav_core = { path = "../nav_core" }
-nav_route = { path = "../nav_route" }
+nav_route = { path = "../nav_route", features = ["osrm", "nominatim", "google_routes", "valhalla", "multi"] }
 flutter_rust_bridge = "=2.11.1"
 anyhow = "1"
 

--- a/native/nav_e_ffi/src/lib.rs
+++ b/native/nav_e_ffi/src/lib.rs
@@ -6,24 +6,78 @@ mod frb_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be
 
 use anyhow::Result;
 use flutter_rust_bridge::frb;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+/// Global handle to the MultiRouteService so `set_routing_engine` can switch
+/// engines without going through AppContainer.
+static MULTI_ROUTER: OnceLock<Arc<nav_route::MultiRouteService>> = OnceLock::new();
 
 // ============================================================================
 // Initialization API
 // ============================================================================
 
-/// Initialize the database with the platform-specific path.
-/// Constructs OSRM routing and Nominatim geocoding services and injects them into nav_core.
-/// Must be called before any database operations.
+/// Initialize the database and routing engines.
+///
+/// Always registers OSRM (public) and Valhalla (public openstreetmap.de instance).
+/// Pass `google_routes_api_key` to also enable Google Routes — obtain a key via
+/// `--dart-define=GOOGLE_ROUTES_KEY=...` at build time.
+///
+/// Must be called before any other API functions.
 #[frb]
-pub fn initialize_database(db_path: String) -> Result<()> {
-    let route_service = Arc::new(nav_route::OsrmRouteService::new(
-        "https://router.project-osrm.org".to_string(),
+pub fn initialize_database(
+    db_path: String,
+    google_routes_api_key: Option<String>,
+) -> Result<()> {
+    let mut engines: HashMap<String, Arc<dyn nav_core::RouteService>> = HashMap::new();
+
+    engines.insert(
+        "osrm".to_string(),
+        Arc::new(nav_route::OsrmRouteService::new(
+            "https://router.project-osrm.org".to_string(),
+        )),
+    );
+
+    engines.insert(
+        "valhalla".to_string(),
+        Arc::new(nav_route::ValhallaRouteService::new(
+            "https://valhalla1.openstreetmap.de".to_string(),
+            None,
+        )),
+    );
+
+    if let Some(key) = google_routes_api_key {
+        if !key.is_empty() {
+            engines.insert(
+                "googleRoutes".to_string(),
+                Arc::new(nav_route::GoogleRoutesService::new(key)),
+            );
+        }
+    }
+
+    let multi = Arc::new(nav_route::MultiRouteService::new(
+        "osrm".to_string(),
+        engines,
     ));
+
+    // Store a typed handle so set_routing_engine can switch the active engine.
+    let _ = MULTI_ROUTER.set(Arc::clone(&multi));
+
     let geocoding_service = Arc::new(nav_route::NominatimGeocodingService::new(
         "https://nominatim.openstreetmap.org".to_string(),
     ));
-    nav_core::api::initialize_database(db_path, route_service, geocoding_service)
+
+    nav_core::api::initialize_database(db_path, multi, geocoding_service)
+}
+
+/// Switch the active routing engine. Valid names: `"osrm"`, `"valhalla"`, `"googleRoutes"`.
+/// Google Routes is only available if an API key was provided to `initialize_database`.
+#[frb]
+pub fn set_routing_engine(engine: String) -> Result<()> {
+    MULTI_ROUTER
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Router not initialized — call initialize_database first"))?
+        .set_engine(&engine)
 }
 
 // ============================================================================

--- a/native/nav_ir/src/adapters/google_routes.rs
+++ b/native/nav_ir/src/adapters/google_routes.rs
@@ -1,0 +1,284 @@
+//! Google Routes API v2 response → Nav-IR Route.
+//!
+//! Normalizes the response from POST /directions/v2:computeRoutes into a Nav-IR Route.
+//! Google encodes polylines at precision 5 (same as OSRM), so no re-encoding is needed.
+//! Distance is already in meters. Duration is a string in "123s" format.
+
+use crate::{
+    BoundingBox, Coordinate, EncodedPolyline, GeometryConfidence, GeometrySource, Route,
+    RouteGeometry, RouteMetadata, RoutePolicies, RouteSegment, SegmentConstraints, SegmentId,
+    SegmentIntent, Waypoint, WaypointId, WaypointKind,
+};
+use chrono::Utc;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct GoogleRoutesResponse {
+    #[serde(default)]
+    routes: Vec<GoogleRoute>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GoogleRoute {
+    polyline: GooglePolyline,
+    distance_meters: u64,
+    /// Duration string in "123s" format.
+    duration: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GooglePolyline {
+    encoded_polyline: String,
+}
+
+/// Normalize a Google Routes API v2 `/directions/v2:computeRoutes` JSON response into a Nav-IR Route.
+///
+/// `waypoints` provides the original (lat, lon) pairs so the route can have correct Start/Via/Stop
+/// markers. If empty, the first and last polyline points are used instead.
+pub fn normalize_google_routes(json: &str, waypoints: &[(f64, f64)]) -> Result<Route, String> {
+    let response: GoogleRoutesResponse =
+        serde_json::from_str(json).map_err(|e| format!("Invalid Google Routes JSON: {}", e))?;
+
+    let route_data = response
+        .routes
+        .first()
+        .ok_or_else(|| "Google Routes response has no routes".to_string())?;
+
+    let geometry = &route_data.polyline.encoded_polyline;
+    let decoded = polyline::decode_polyline(geometry, 5)
+        .map_err(|e| format!("Failed to decode Google Routes polyline: {}", e))?;
+
+    let coords: Vec<_> = decoded.0;
+    if coords.len() < 2 {
+        return Err("Google Routes geometry has fewer than 2 points".to_string());
+    }
+
+    let (min_lat, max_lat, min_lon, max_lon) = coords.iter().fold(
+        (90.0_f64, -90.0_f64, 180.0_f64, -180.0_f64),
+        |(min_lat, max_lat, min_lon, max_lon), c| {
+            (
+                min_lat.min(c.y),
+                max_lat.max(c.y),
+                min_lon.min(c.x),
+                max_lon.max(c.x),
+            )
+        },
+    );
+
+    // Duration: strip trailing "s", parse as u64 (e.g. "1234s" → 1234)
+    let duration_str = route_data.duration.trim_end_matches('s');
+    let duration_s: u64 = duration_str
+        .parse()
+        .map_err(|_| format!("Failed to parse duration '{}'", route_data.duration))?;
+
+    let wps: Vec<Waypoint> = if waypoints.is_empty() {
+        let first = &coords[0];
+        let last = &coords[coords.len() - 1];
+        vec![
+            Waypoint {
+                id: WaypointId::new(),
+                coordinate: Coordinate::new(first.y, first.x),
+                kind: WaypointKind::Start,
+                radius_m: None,
+                name: None,
+                description: None,
+                role: None,
+                category: None,
+                geometry_ref: None,
+            },
+            Waypoint {
+                id: WaypointId::new(),
+                coordinate: Coordinate::new(last.y, last.x),
+                kind: WaypointKind::Stop,
+                radius_m: None,
+                name: None,
+                description: None,
+                role: None,
+                category: None,
+                geometry_ref: None,
+            },
+        ]
+    } else {
+        let n = waypoints.len();
+        waypoints
+            .iter()
+            .enumerate()
+            .map(|(i, &(lat, lon))| {
+                let kind = if i == 0 {
+                    WaypointKind::Start
+                } else if i == n - 1 {
+                    WaypointKind::Stop
+                } else {
+                    WaypointKind::Via
+                };
+                Waypoint {
+                    id: WaypointId::new(),
+                    coordinate: Coordinate::new(lat, lon),
+                    kind,
+                    radius_m: None,
+                    name: None,
+                    description: None,
+                    role: None,
+                    category: None,
+                    geometry_ref: None,
+                }
+            })
+            .collect()
+    };
+
+    if wps.len() < 2 {
+        return Err("Need at least two waypoints (Start and Stop)".to_string());
+    }
+
+    let now = Utc::now();
+    let route = Route {
+        schema_version: Route::CURRENT_SCHEMA_VERSION,
+        id: crate::RouteId::new(),
+        metadata: RouteMetadata {
+            name: String::new(),
+            description: None,
+            created_at: now,
+            updated_at: now,
+            total_distance_m: Some(route_data.distance_meters as f64),
+            estimated_duration_s: Some(duration_s),
+            tags: vec![],
+            source: None,
+        },
+        segments: vec![RouteSegment {
+            id: SegmentId::new(),
+            intent: SegmentIntent::Recalculatable,
+            geometry: RouteGeometry {
+                polyline: EncodedPolyline(geometry.clone()),
+                source: GeometrySource::SnappedToGraph,
+                confidence: GeometryConfidence::High,
+                bounding_box: BoundingBox {
+                    min_lat,
+                    min_lon,
+                    max_lat,
+                    max_lon,
+                },
+            },
+            waypoints: wps,
+            legs: vec![],
+            instructions: vec![],
+            constraints: SegmentConstraints::default(),
+        }],
+        policies: RoutePolicies::default(),
+    };
+
+    route.validate().map_err(|e| e.to_string())?;
+    Ok(route)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo_types::Coord;
+
+    fn make_polyline5(coords: &[(f64, f64)]) -> String {
+        let geo_coords: Vec<Coord<f64>> = coords
+            .iter()
+            .map(|(lat, lon)| Coord { x: *lon, y: *lat })
+            .collect();
+        polyline::encode_coordinates(geo_coords, 5).unwrap()
+    }
+
+    #[test]
+    fn normalize_google_routes_basic() {
+        let polyline = make_polyline5(&[(40.7128, -74.0060), (40.7580, -73.9855)]);
+        let json = format!(
+            r#"{{
+                "routes": [{{
+                    "polyline": {{"encodedPolyline": "{polyline}"}},
+                    "distanceMeters": 8500,
+                    "duration": "1020s"
+                }}]
+            }}"#
+        );
+
+        let waypoints = [(40.7128, -74.0060), (40.7580, -73.9855)];
+        let route = normalize_google_routes(&json, &waypoints).unwrap();
+        assert_eq!(route.segments.len(), 1);
+        let seg = &route.segments[0];
+        assert_eq!(seg.waypoints.len(), 2);
+        assert_eq!(seg.waypoints[0].kind, WaypointKind::Start);
+        assert_eq!(seg.waypoints[1].kind, WaypointKind::Stop);
+        assert!((route.metadata.total_distance_m.unwrap() - 8500.0).abs() < 1.0);
+        assert_eq!(route.metadata.estimated_duration_s, Some(1020));
+        assert_eq!(seg.intent, SegmentIntent::Recalculatable);
+    }
+
+    #[test]
+    fn normalize_google_routes_via_waypoint() {
+        let polyline = make_polyline5(&[
+            (40.7128, -74.0060),
+            (40.7350, -73.9950),
+            (40.7580, -73.9855),
+        ]);
+        let json = format!(
+            r#"{{
+                "routes": [{{
+                    "polyline": {{"encodedPolyline": "{polyline}"}},
+                    "distanceMeters": 12000,
+                    "duration": "1500s"
+                }}]
+            }}"#
+        );
+
+        let waypoints = [
+            (40.7128, -74.0060),
+            (40.7350, -73.9950),
+            (40.7580, -73.9855),
+        ];
+        let route = normalize_google_routes(&json, &waypoints).unwrap();
+        let seg = &route.segments[0];
+        assert_eq!(seg.waypoints.len(), 3);
+        assert_eq!(seg.waypoints[1].kind, WaypointKind::Via);
+    }
+
+    #[test]
+    fn normalize_google_routes_fallback_to_geometry_endpoints() {
+        let polyline = make_polyline5(&[(40.7128, -74.0060), (40.7580, -73.9855)]);
+        let json = format!(
+            r#"{{
+                "routes": [{{
+                    "polyline": {{"encodedPolyline": "{polyline}"}},
+                    "distanceMeters": 5000,
+                    "duration": "600s"
+                }}]
+            }}"#
+        );
+
+        let route = normalize_google_routes(&json, &[]).unwrap();
+        let seg = &route.segments[0];
+        assert_eq!(seg.waypoints.len(), 2);
+        assert_eq!(seg.waypoints[0].kind, WaypointKind::Start);
+        assert_eq!(seg.waypoints[1].kind, WaypointKind::Stop);
+    }
+
+    #[test]
+    fn normalize_google_routes_rejects_empty_routes() {
+        let json = r#"{"routes": []}"#;
+        assert!(normalize_google_routes(json, &[]).is_err());
+    }
+
+    #[test]
+    fn normalize_google_routes_parses_duration_without_s_suffix() {
+        // Defensive: handle "1020" without the "s" suffix
+        let polyline = make_polyline5(&[(40.7128, -74.0060), (40.7580, -73.9855)]);
+        let json = format!(
+            r#"{{
+                "routes": [{{
+                    "polyline": {{"encodedPolyline": "{polyline}"}},
+                    "distanceMeters": 5000,
+                    "duration": "1020"
+                }}]
+            }}"#
+        );
+        // "1020".trim_end_matches('s') == "1020", so still valid
+        let route = normalize_google_routes(&json, &[]).unwrap();
+        assert_eq!(route.metadata.estimated_duration_s, Some(1020));
+    }
+}

--- a/native/nav_ir/src/adapters/mod.rs
+++ b/native/nav_ir/src/adapters/mod.rs
@@ -5,10 +5,14 @@
 
 mod custom_api;
 mod gpx;
+mod google_routes;
 mod graphhopper;
 mod osrm;
+mod valhalla;
 
 pub use custom_api::normalize_custom;
 pub use gpx::normalize_gpx;
+pub use google_routes::normalize_google_routes;
 pub use graphhopper::normalize_graphhopper;
 pub use osrm::{normalize_osrm, OsrmResponse};
+pub use valhalla::normalize_valhalla;

--- a/native/nav_ir/src/adapters/valhalla.rs
+++ b/native/nav_ir/src/adapters/valhalla.rs
@@ -1,0 +1,292 @@
+//! Valhalla API response → Nav-IR Route.
+//!
+//! Normalizes the response from POST /route (Valhalla HTTP API) into a single Nav-IR Route.
+//!
+//! Critical precision note: Valhalla encodes `trip.legs[].shape` at **precision 6** (polyline6),
+//! while Nav-IR uses precision 5 everywhere. This adapter decodes at 6 and re-encodes at 5.
+//! Distance is in km in the summary — multiply by 1000 to get meters.
+
+use crate::{
+    BoundingBox, Coordinate, EncodedPolyline, GeometryConfidence, GeometrySource, Route,
+    RouteGeometry, RouteMetadata, RoutePolicies, RouteSegment, SegmentConstraints, SegmentId,
+    SegmentIntent, Waypoint, WaypointId, WaypointKind,
+};
+use chrono::Utc;
+use geo_types::Coord;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct ValhallaResponse {
+    trip: ValhallaTrip,
+}
+
+#[derive(Debug, Deserialize)]
+struct ValhallaTrip {
+    legs: Vec<ValhallaLeg>,
+    summary: ValhallaSummary,
+    #[serde(default)]
+    locations: Vec<ValhallaLocation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ValhallaLeg {
+    shape: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ValhallaSummary {
+    /// Route length in **kilometers**.
+    length: f64,
+    /// Route duration in **seconds**.
+    time: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ValhallaLocation {
+    lat: f64,
+    lon: f64,
+}
+
+/// Normalize a Valhalla POST `/route` JSON response into a Nav-IR Route.
+///
+/// Decodes `trip.legs[0].shape` at polyline precision 6, re-encodes at precision 5.
+/// `trip.summary.length` (km) is converted to meters; `trip.summary.time` (seconds) used directly.
+/// Waypoints are taken from `trip.locations` if present, otherwise from geometry endpoints.
+pub fn normalize_valhalla(json: &str) -> Result<Route, String> {
+    let response: ValhallaResponse =
+        serde_json::from_str(json).map_err(|e| format!("Invalid Valhalla JSON: {}", e))?;
+    let trip = &response.trip;
+
+    let shape = trip
+        .legs
+        .first()
+        .ok_or_else(|| "Valhalla response has no legs".to_string())?
+        .shape
+        .as_str();
+
+    // Valhalla uses polyline6; Nav-IR uses precision 5.
+    let decoded = polyline::decode_polyline(shape, 6)
+        .map_err(|e| format!("Failed to decode Valhalla polyline6: {}", e))?;
+
+    let coords: Vec<Coord<f64>> = decoded.0.clone();
+    if coords.len() < 2 {
+        return Err("Valhalla geometry has fewer than 2 points".to_string());
+    }
+
+    let re_encoded = polyline::encode_coordinates(coords.clone(), 5)
+        .map_err(|e| format!("Failed to re-encode to polyline5: {}", e))?;
+
+    let (min_lat, max_lat, min_lon, max_lon) = coords.iter().fold(
+        (90.0_f64, -90.0_f64, 180.0_f64, -180.0_f64),
+        |(min_lat, max_lat, min_lon, max_lon), c| {
+            (
+                min_lat.min(c.y),
+                max_lat.max(c.y),
+                min_lon.min(c.x),
+                max_lon.max(c.x),
+            )
+        },
+    );
+
+    let waypoints: Vec<Waypoint> = if trip.locations.is_empty() {
+        let first = &coords[0];
+        let last = &coords[coords.len() - 1];
+        vec![
+            Waypoint {
+                id: WaypointId::new(),
+                coordinate: Coordinate::new(first.y, first.x),
+                kind: WaypointKind::Start,
+                radius_m: None,
+                name: None,
+                description: None,
+                role: None,
+                category: None,
+                geometry_ref: None,
+            },
+            Waypoint {
+                id: WaypointId::new(),
+                coordinate: Coordinate::new(last.y, last.x),
+                kind: WaypointKind::Stop,
+                radius_m: None,
+                name: None,
+                description: None,
+                role: None,
+                category: None,
+                geometry_ref: None,
+            },
+        ]
+    } else {
+        let n = trip.locations.len();
+        trip.locations
+            .iter()
+            .enumerate()
+            .map(|(i, loc)| {
+                let kind = if i == 0 {
+                    WaypointKind::Start
+                } else if i == n - 1 {
+                    WaypointKind::Stop
+                } else {
+                    WaypointKind::Via
+                };
+                Waypoint {
+                    id: WaypointId::new(),
+                    coordinate: Coordinate::new(loc.lat, loc.lon),
+                    kind,
+                    radius_m: None,
+                    name: None,
+                    description: None,
+                    role: None,
+                    category: None,
+                    geometry_ref: None,
+                }
+            })
+            .collect()
+    };
+
+    if waypoints.len() < 2 {
+        return Err("Need at least two waypoints (Start and Stop)".to_string());
+    }
+
+    let now = Utc::now();
+    let route = Route {
+        schema_version: Route::CURRENT_SCHEMA_VERSION,
+        id: crate::RouteId::new(),
+        metadata: RouteMetadata {
+            name: String::new(),
+            description: None,
+            created_at: now,
+            updated_at: now,
+            total_distance_m: Some(trip.summary.length * 1000.0),
+            estimated_duration_s: Some(trip.summary.time as u64),
+            tags: vec![],
+            source: None,
+        },
+        segments: vec![RouteSegment {
+            id: SegmentId::new(),
+            intent: SegmentIntent::Recalculatable,
+            geometry: RouteGeometry {
+                polyline: EncodedPolyline(re_encoded),
+                source: GeometrySource::SnappedToGraph,
+                confidence: GeometryConfidence::High,
+                bounding_box: BoundingBox {
+                    min_lat,
+                    min_lon,
+                    max_lat,
+                    max_lon,
+                },
+            },
+            waypoints,
+            legs: vec![],
+            instructions: vec![],
+            constraints: SegmentConstraints::default(),
+        }],
+        policies: RoutePolicies::default(),
+    };
+
+    route.validate().map_err(|e| e.to_string())?;
+    Ok(route)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_polyline6(coords: &[(f64, f64)]) -> String {
+        // coords are (lat, lon)
+        let geo_coords: Vec<Coord<f64>> = coords
+            .iter()
+            .map(|(lat, lon)| Coord { x: *lon, y: *lat })
+            .collect();
+        polyline::encode_coordinates(geo_coords, 6).unwrap()
+    }
+
+    #[test]
+    fn normalize_valhalla_two_locations() {
+        let shape = make_polyline6(&[(40.7128, -74.0060), (40.7580, -73.9855)]);
+        let json = format!(
+            r#"{{
+                "trip": {{
+                    "legs": [{{"shape": "{shape}"}}],
+                    "summary": {{"length": 5.0, "time": 600.0}},
+                    "locations": [
+                        {{"lat": 40.7128, "lon": -74.0060, "type": "break"}},
+                        {{"lat": 40.7580, "lon": -73.9855, "type": "break"}}
+                    ]
+                }}
+            }}"#
+        );
+
+        let route = normalize_valhalla(&json).unwrap();
+        assert_eq!(route.segments.len(), 1);
+        let seg = &route.segments[0];
+        assert_eq!(seg.waypoints.len(), 2);
+        assert_eq!(seg.waypoints[0].kind, WaypointKind::Start);
+        assert_eq!(seg.waypoints[1].kind, WaypointKind::Stop);
+        assert!((route.metadata.total_distance_m.unwrap() - 5000.0).abs() < 1.0);
+        assert_eq!(route.metadata.estimated_duration_s, Some(600));
+        assert_eq!(seg.intent, SegmentIntent::Recalculatable);
+    }
+
+    #[test]
+    fn normalize_valhalla_via_waypoint() {
+        let shape = make_polyline6(&[
+            (40.7128, -74.0060),
+            (40.7350, -73.9950),
+            (40.7580, -73.9855),
+        ]);
+        let json = format!(
+            r#"{{
+                "trip": {{
+                    "legs": [{{"shape": "{shape}"}}],
+                    "summary": {{"length": 8.5, "time": 1020.0}},
+                    "locations": [
+                        {{"lat": 40.7128, "lon": -74.0060, "type": "break"}},
+                        {{"lat": 40.7350, "lon": -73.9950, "type": "through"}},
+                        {{"lat": 40.7580, "lon": -73.9855, "type": "break"}}
+                    ]
+                }}
+            }}"#
+        );
+
+        let route = normalize_valhalla(&json).unwrap();
+        let seg = &route.segments[0];
+        assert_eq!(seg.waypoints.len(), 3);
+        assert_eq!(seg.waypoints[0].kind, WaypointKind::Start);
+        assert_eq!(seg.waypoints[1].kind, WaypointKind::Via);
+        assert_eq!(seg.waypoints[2].kind, WaypointKind::Stop);
+        assert!((route.metadata.total_distance_m.unwrap() - 8500.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn normalize_valhalla_fallback_to_geometry_endpoints() {
+        // No locations — should use first/last polyline points
+        let shape = make_polyline6(&[(40.7128, -74.0060), (40.7580, -73.9855)]);
+        let json = format!(
+            r#"{{
+                "trip": {{
+                    "legs": [{{"shape": "{shape}"}}],
+                    "summary": {{"length": 5.0, "time": 600.0}},
+                    "locations": []
+                }}
+            }}"#
+        );
+
+        let route = normalize_valhalla(&json).unwrap();
+        let seg = &route.segments[0];
+        assert_eq!(seg.waypoints.len(), 2);
+        assert_eq!(seg.waypoints[0].kind, WaypointKind::Start);
+        assert_eq!(seg.waypoints[1].kind, WaypointKind::Stop);
+    }
+
+    #[test]
+    fn normalize_valhalla_rejects_missing_legs() {
+        let json = r#"{
+            "trip": {
+                "legs": [],
+                "summary": {"length": 5.0, "time": 600.0},
+                "locations": []
+            }
+        }"#;
+        assert!(normalize_valhalla(json).is_err());
+    }
+}

--- a/native/nav_ir/src/lib.rs
+++ b/native/nav_ir/src/lib.rs
@@ -7,7 +7,8 @@ mod adapters;
 mod types;
 
 pub use adapters::{
-    normalize_custom, normalize_gpx, normalize_graphhopper, normalize_osrm, OsrmResponse,
+    normalize_custom, normalize_google_routes, normalize_gpx, normalize_graphhopper,
+    normalize_osrm, normalize_valhalla, OsrmResponse,
 };
 pub use types::*;
 

--- a/native/nav_route/Cargo.toml
+++ b/native/nav_route/Cargo.toml
@@ -8,6 +8,9 @@ description = "HTTP routing and geocoding service implementations for nav_core p
 default = ["osrm", "nominatim"]
 osrm = ["dep:reqwest"]
 nominatim = ["dep:reqwest", "dep:urlencoding"]
+google_routes = ["dep:reqwest"]
+valhalla = ["dep:reqwest"]
+multi = []
 
 [dependencies]
 nav_core = { path = "../nav_core" }

--- a/native/nav_route/src/google_routes/mod.rs
+++ b/native/nav_route/src/google_routes/mod.rs
@@ -1,0 +1,133 @@
+// Google Routes API v2 Adapter — implements nav_core's RouteService port.
+//
+// POST https://routes.googleapis.com/directions/v2:computeRoutes
+// Headers: X-Goog-Api-Key, X-Goog-FieldMask
+//
+// API key is NOT hardcoded here. Pass it via `--dart-define=GOOGLE_ROUTES_KEY=...` at build
+// time and hand it to `initialize_database(google_routes_api_key: Some(key))` in FFI.
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use nav_ir::{normalize_google_routes, Route as NavIrRoute};
+use serde_json::json;
+
+const GOOGLE_ROUTES_URL: &str =
+    "https://routes.googleapis.com/directions/v2:computeRoutes";
+
+pub struct GoogleRoutesService {
+    api_key: String,
+    client: reqwest::Client,
+}
+
+impl GoogleRoutesService {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl nav_core::RouteService for GoogleRoutesService {
+    async fn calculate_route(&self, waypoints: Vec<nav_core::Position>) -> Result<NavIrRoute> {
+        if waypoints.len() < 2 {
+            anyhow::bail!("Google Routes requires at least two waypoints");
+        }
+
+        let origin = &waypoints[0];
+        let destination = &waypoints[waypoints.len() - 1];
+
+        let mut body = json!({
+            "origin": {
+                "location": {
+                    "latLng": {
+                        "latitude": origin.latitude,
+                        "longitude": origin.longitude
+                    }
+                }
+            },
+            "destination": {
+                "location": {
+                    "latLng": {
+                        "latitude": destination.latitude,
+                        "longitude": destination.longitude
+                    }
+                }
+            },
+            "travelMode": "DRIVE"
+        });
+
+        if waypoints.len() > 2 {
+            let intermediates: Vec<serde_json::Value> = waypoints[1..waypoints.len() - 1]
+                .iter()
+                .map(|p| {
+                    json!({
+                        "location": {
+                            "latLng": {
+                                "latitude": p.latitude,
+                                "longitude": p.longitude
+                            }
+                        }
+                    })
+                })
+                .collect();
+            body["intermediates"] = json!(intermediates);
+        }
+
+        let raw_waypoints: Vec<(f64, f64)> = waypoints
+            .iter()
+            .map(|p| (p.latitude, p.longitude))
+            .collect();
+
+        let response = self
+            .client
+            .post(GOOGLE_ROUTES_URL)
+            .header("X-Goog-Api-Key", &self.api_key)
+            .header(
+                "X-Goog-FieldMask",
+                "routes.polyline,routes.distanceMeters,routes.duration",
+            )
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(15))
+            .send()
+            .await
+            .context("Failed to send Google Routes request")?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            anyhow::bail!("Google Routes returned error status: {}", error_text);
+        }
+
+        let response_text = response
+            .text()
+            .await
+            .context("Failed to read Google Routes response body")?;
+
+        normalize_google_routes(&response_text, &raw_waypoints)
+            .map_err(|e| anyhow::anyhow!("Google Routes normalization failed: {}", e))
+    }
+
+    async fn recalculate_from_position(
+        &self,
+        route: &NavIrRoute,
+        current_position: nav_core::Position,
+    ) -> Result<NavIrRoute> {
+        let waypoints: Vec<nav_core::Position> = route
+            .segments
+            .iter()
+            .flat_map(|s| s.waypoints.iter())
+            .map(|w| {
+                nav_core::Position::new(w.coordinate.latitude, w.coordinate.longitude).unwrap()
+            })
+            .collect();
+        if waypoints.is_empty() {
+            return self.calculate_route(vec![current_position]).await;
+        }
+        let mut new_waypoints = vec![current_position];
+        new_waypoints.extend(waypoints.into_iter().skip(1));
+        self.calculate_route(new_waypoints).await
+    }
+}

--- a/native/nav_route/src/lib.rs
+++ b/native/nav_route/src/lib.rs
@@ -12,3 +12,18 @@ pub use osrm::OsrmRouteService;
 pub mod geocoding;
 #[cfg(feature = "nominatim")]
 pub use geocoding::{NominatimGeocodingService, PhotonGeocodingService};
+
+#[cfg(feature = "google_routes")]
+pub mod google_routes;
+#[cfg(feature = "google_routes")]
+pub use google_routes::GoogleRoutesService;
+
+#[cfg(feature = "valhalla")]
+pub mod valhalla;
+#[cfg(feature = "valhalla")]
+pub use valhalla::ValhallaRouteService;
+
+#[cfg(feature = "multi")]
+pub mod multi;
+#[cfg(feature = "multi")]
+pub use multi::MultiRouteService;

--- a/native/nav_route/src/multi.rs
+++ b/native/nav_route/src/multi.rs
@@ -1,0 +1,71 @@
+//! MultiRouteService — runtime-switchable routing engine dispatcher.
+//!
+//! Implements nav_core's `RouteService` port. Holds a registry of named engines and an
+//! `std::sync::RwLock<String>` active-engine key. On every `calculate_route` call it reads
+//! the current key, clones the `Arc` to the selected engine (releasing the lock), then
+//! delegates — no lock held across `.await` points.
+//!
+//! Constructed once by `nav_e_ffi::initialize_database` and stored in a `OnceLock` so that
+//! `set_routing_engine` can update the active key without touching `AppContainer`.
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use nav_ir::Route as NavIrRoute;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+pub struct MultiRouteService {
+    engines: HashMap<String, Arc<dyn nav_core::RouteService>>,
+    active: RwLock<String>,
+}
+
+impl MultiRouteService {
+    /// Create a dispatcher with `default` as the initially active engine.
+    ///
+    /// Panics if `default` is not a key in `engines`.
+    pub fn new(default: String, engines: HashMap<String, Arc<dyn nav_core::RouteService>>) -> Self {
+        assert!(
+            engines.contains_key(&default),
+            "MultiRouteService: default engine '{}' not found in engines map",
+            default
+        );
+        Self {
+            engines,
+            active: RwLock::new(default),
+        }
+    }
+
+    /// Switch the active engine by name. Returns an error if `name` is not registered.
+    pub fn set_engine(&self, name: &str) -> Result<()> {
+        if !self.engines.contains_key(name) {
+            return Err(anyhow!("Unknown routing engine: '{}'", name));
+        }
+        *self.active.write().unwrap() = name.to_string();
+        Ok(())
+    }
+
+    fn active_engine(&self) -> Result<Arc<dyn nav_core::RouteService>> {
+        let name = self.active.read().unwrap();
+        self.engines
+            .get(name.as_str())
+            .cloned()
+            .ok_or_else(|| anyhow!("Active routing engine '{}' not found", *name))
+    }
+}
+
+#[async_trait]
+impl nav_core::RouteService for MultiRouteService {
+    async fn calculate_route(&self, waypoints: Vec<nav_core::Position>) -> Result<NavIrRoute> {
+        self.active_engine()?.calculate_route(waypoints).await
+    }
+
+    async fn recalculate_from_position(
+        &self,
+        route: &NavIrRoute,
+        current_position: nav_core::Position,
+    ) -> Result<NavIrRoute> {
+        self.active_engine()?
+            .recalculate_from_position(route, current_position)
+            .await
+    }
+}

--- a/native/nav_route/src/valhalla/mod.rs
+++ b/native/nav_route/src/valhalla/mod.rs
@@ -1,0 +1,102 @@
+// Valhalla HTTP Adapter — implements nav_core's RouteService port.
+//
+// Supports both self-hosted Valhalla (e.g. valhalla1.openstreetmap.de) and
+// Stadia Maps (pass api_key for the "api-key" header). Costing defaults to "auto".
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use nav_ir::{normalize_valhalla, Route as NavIrRoute};
+use serde_json::json;
+
+pub struct ValhallaRouteService {
+    base_url: String,
+    /// Optional API key sent as the `api-key` header (required for Stadia Maps).
+    api_key: Option<String>,
+    /// Valhalla costing model: "auto" | "bicycle" | "pedestrian" | …
+    costing: String,
+    client: reqwest::Client,
+}
+
+impl ValhallaRouteService {
+    pub fn new(base_url: String, api_key: Option<String>) -> Self {
+        Self {
+            base_url,
+            api_key,
+            costing: "auto".to_string(),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl nav_core::RouteService for ValhallaRouteService {
+    async fn calculate_route(&self, waypoints: Vec<nav_core::Position>) -> Result<NavIrRoute> {
+        let locations: Vec<serde_json::Value> = waypoints
+            .iter()
+            .map(|p| {
+                json!({
+                    "lon": p.longitude,
+                    "lat": p.latitude,
+                    "type": "break"
+                })
+            })
+            .collect();
+
+        let body = json!({
+            "locations": locations,
+            "costing": self.costing
+        });
+
+        let url = format!("{}/route", self.base_url);
+        let mut request = self
+            .client
+            .post(&url)
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(15));
+
+        if let Some(key) = &self.api_key {
+            request = request.header("api-key", key);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to send Valhalla request")?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            anyhow::bail!("Valhalla returned error status: {}", error_text);
+        }
+
+        let response_text = response
+            .text()
+            .await
+            .context("Failed to read Valhalla response body")?;
+
+        normalize_valhalla(&response_text)
+            .map_err(|e| anyhow::anyhow!("Valhalla normalization failed: {}", e))
+    }
+
+    async fn recalculate_from_position(
+        &self,
+        route: &NavIrRoute,
+        current_position: nav_core::Position,
+    ) -> Result<NavIrRoute> {
+        let waypoints: Vec<nav_core::Position> = route
+            .segments
+            .iter()
+            .flat_map(|s| s.waypoints.iter())
+            .map(|w| {
+                nav_core::Position::new(w.coordinate.latitude, w.coordinate.longitude).unwrap()
+            })
+            .collect();
+        if waypoints.is_empty() {
+            return self.calculate_route(vec![current_position]).await;
+        }
+        let mut new_waypoints = vec![current_position];
+        new_waypoints.extend(waypoints.into_iter().skip(1));
+        self.calculate_route(new_waypoints).await
+    }
+}


### PR DESCRIPTION
- Add google_routes, valhalla, multi feature flags to nav_route
- Export GoogleRoutesService, ValhallaRouteService, MultiRouteService from nav_route
- Wire normalize_google_routes and normalize_valhalla into nav_ir::adapters
- Refactor initialize_database to build MultiRouteService (OSRM + Valhalla always, Google Routes when GOOGLE_ROUTES_KEY dart-define is set) and store in OnceLock
- Add set_routing_engine FFI wrapper delegating to MultiRouteService::set_engine
- Pass GOOGLE_ROUTES_KEY from dart-define in main.dart

Fixes the crash when users open routing engine settings (set_routing_engine was called in Dart but had no Rust implementation).

NOTE: requires make codegen to regenerate lib/bridge/ bindings.

## Summary
What does this change?

## Type
- [ ] feat
- [ ] fix
- [ ] chore/refactor
- [ ] docs
- [ ] ci/build
- [ ] test

## Checklist
- [ ] PR title follows Conventional Commits
- [ ] `dart analyze` passes
- [ ] Tests added/updated
- [ ] Builds locally (`flutter build apk --debug`)

> [!NOTE]
> FFI bindings are auto-generated on merge to main. Don't commit `lib/bridge/generated/` files.
