### PR TITLE
refactor(tech): address architecture problem areas

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,33 +25,7 @@ jobs:
           fetch-depth: 0
           
       - name: Validate release conditions
-        run: |
-          # Ensure we're on main and clean
-          git fetch origin main --tags
-          [[ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]] || (echo "❌ Not on main branch" && exit 1)
-          test -z "$(git status --porcelain)" || (echo "❌ Workspace not clean" && exit 1)
-          
-          # Validate version format
-          if ! [[ "${{ github.event.inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ Invalid version format. Use semantic versioning (e.g., 1.2.3)"
-            exit 1
-          fi
-          
-          # Check if tag already exists
-          if git tag | grep -q "^v${{ github.event.inputs.version }}$"; then
-            echo "❌ Tag v${{ github.event.inputs.version }} already exists"
-            exit 1
-          fi
-          
-          # Validate pubspec version matches input
-          PUBSPEC_VERSION=$(grep -E '^version:' pubspec.yaml | awk '{print $2}' | cut -d+ -f1)
-          if [ "$PUBSPEC_VERSION" != "${{ github.event.inputs.version }}" ]; then
-            echo "❌ pubspec.yaml version ($PUBSPEC_VERSION) doesn't match input (${{ github.event.inputs.version }})"
-            echo "💡 Please update pubspec.yaml first"
-            exit 1
-          fi
-          
-          echo "✅ All validation checks passed"
+        run: bash scripts/validate_release.sh "${{ github.event.inputs.version }}"
       
       - name: Install apt packages
         run: |

--- a/docs/flutter/app.md
+++ b/docs/flutter/app.md
@@ -1,0 +1,833 @@
+# nav_e Flutter App
+
+The Flutter application layer: map-based navigation UI backed by a Rust core via flutter_rust_bridge FFI.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                      app/                            │
+│  main.dart  ·  app_router.dart  ·  app_shell.dart   │
+└────────────────────────┬─────────────────────────────┘
+                         │ BlocProvider / GoRouter
+┌────────────────────────▼─────────────────────────────┐
+│                     core/                            │
+│  bloc/        Global BLoCs (Location, Bluetooth,     │
+│               MapBloc, DeviceComm, ThemeCubit)       │
+│  domain/      Entities + repository interfaces       │
+│  theme/       AppSpacing · AppColors · AppElevation  │
+│  device_comm/ DeviceCommunicationService (BLE)       │
+│  routing/     RoutingEngineService (SharedPrefs)     │
+│  nav/         NavSettingsService                     │
+│  notifications/ NavNotificationService               │
+└────────────────────────┬─────────────────────────────┘
+                         │
+┌────────────────────────▼─────────────────────────────┐
+│                   features/ (15)                     │
+│  Each feature owns its own BLoC/Cubit, screens,      │
+│  widgets, and data adapters. Data adapters call into │
+│  the Rust FFI or platform services.                  │
+└────────────────────────┬─────────────────────────────┘
+                         │
+┌────────────────────────▼─────────────────────────────┐
+│               bridge/  (GENERATED — do not edit)     │
+│  lib.dart  ·  frb_generated.dart                    │
+│  import 'package:nav_e/bridge/lib.dart' as api;      │
+└──────────────────────────────────────────────────────┘
+```
+
+### Global vs scoped state
+
+| Scope | Provider | Examples |
+|---|---|---|
+| App root (`main.dart`) | `BlocProvider` at `MaterialApp` level | `LocationBloc`, `BluetoothBloc`, `MapBloc`, `DeviceCommBloc`, `ThemeCubit`, `SavedPlacesCubit`, `SavedRoutesCubit`, `TripHistoryCubit`, `OfflineMapsCubit`, `PreviewCubit` |
+| Route-scoped | `BlocProvider` inside route builder | `NavBloc`, `SearchBloc`, `DevicesBloc` |
+
+### BLoC vs Cubit split
+
+**BLoC** (event-driven; complex state machines):
+- `NavBloc` — turn-by-turn navigation with off-route detection and rerouting
+- `SearchBloc` — geocoding with debounce and history
+- `DevicesBloc` — device CRUD via Rust FFI
+- `MapBloc` — camera, polylines, map source, data layers
+- `DeviceCommBloc` — BLE route/map transmission
+
+**Cubit** (simple emit-based; list/flag state):
+- `ThemeCubit`, `SavedPlacesCubit`, `SavedRoutesCubit`, `TripHistoryCubit`, `OfflineMapsCubit`, `PreviewCubit`
+
+---
+
+## App initialization
+
+### Startup sequence (`main.dart`)
+
+```
+main()
+ └─ RustLib.init()               // initialise flutter_rust_bridge
+ └─ WidgetsFlutterBinding         // Flutter engine
+ └─ _AppLoader widget
+     ├─ api.initializeDatabase(dbPath)   // Rust SQLite setup
+     ├─ Build RepositoryProvider tree   // 7 repository singletons
+     ├─ Build BlocProvider tree         // global BLoCs + Cubits
+     ├─ Check api.getActiveSession()    // restore in-progress session
+     └─ NavE (MaterialApp.router)
+         └─ GoRouter (app_router.dart)
+```
+
+Active session restoration: if `getActiveSession()` returns a non-null `Session`, a banner is shown offering to resume. Pending GPX imports arriving via platform channel are forwarded to `SavedRoutesCubit` before the first frame.
+
+### Global BLoC providers (in order)
+
+```dart
+// Repositories (innermost first):
+RepositoryProvider<GeocodingRepository>
+RepositoryProvider<SavedPlacesRepository>
+RepositoryProvider<SavedRoutesRepository>
+RepositoryProvider<TripRepository>
+RepositoryProvider<MapSourceRepository>
+RepositoryProvider<DeviceRepository>
+RepositoryProvider<OfflineRegionsRepository>
+
+// BLoCs / Cubits:
+BlocProvider<ThemeCubit>
+BlocProvider<LocationBloc>
+BlocProvider<BluetoothBloc>
+BlocProvider<MapBloc>
+BlocProvider<DeviceCommBloc>
+BlocProvider<SavedPlacesCubit>
+BlocProvider<SavedRoutesCubit>
+BlocProvider<TripHistoryCubit>
+BlocProvider<OfflineMapsCubit>
+BlocProvider<PreviewCubit>
+```
+
+### Named routes (`app_router.dart`)
+
+GoRouter with a `StatefulShellRoute` providing four indexed branches:
+
+| Branch | Index | Root path |
+|---|---|---|
+| Home / Explore | 0 | `/` |
+| Plan | 1 | `/plan` |
+| Saved Routes | 2 | `/saved-routes` |
+| Profile | 3 | `/profile` |
+
+Top-level routes (rendered above the shell):
+
+| Name | Path | Description |
+|---|---|---|
+| `activeNav` | `/active-nav` | Turn-by-turn navigation screen |
+| `planRoute` | `/plan-route` | Route planning with map preview |
+| `search` | `/search` | Geocoding search screen |
+| `savedPlaces` | `/saved-places` | User-saved places list |
+| `tripHistory` | `/trip-history` | Completed trip list |
+| `tripDetail` | `/trip-detail` | Individual trip replay |
+| `deviceManagement` | `/device-management` | BLE device list + pairing |
+| `addDevice` | `/add-device` | New device registration |
+| `offlineMaps` | `/offline-maps` | Downloaded region manager |
+| `settings` | `/settings` | App settings |
+| `licenses` | `/licenses` | OSS license viewer |
+| `deviceCommDebug` | `/device-comm-debug` | BLE debug console (dev) |
+| `importPreview` | `/import-preview` | GPX import confirmation |
+| `routeFinish` | `/route-finish` | Post-navigation summary |
+| `locationPreview` | `/location-preview` | Tapped-point detail sheet |
+
+Redirect guards validate `extra` state (e.g. `/plan-route` requires a `GeocodingResult`; `/active-nav` requires a `Session`).
+
+---
+
+## Core infrastructure
+
+### Global BLoCs
+
+#### LocationBloc (`lib/core/bloc/location_bloc.dart`)
+
+Streams GPS position, heading, and speed from the platform location API. All features that need the user's position listen to this bloc rather than subscribing to location directly.
+
+Key state fields: `position: LatLng?`, `heading: double?`, `speed: double?`, `accuracy: double?`.
+
+#### BluetoothBloc (`lib/core/bloc/bluetooth/`)
+
+Manages BLE adapter state and device scan results. Consumed by `DeviceManagementScreen` and `DeviceCommBloc`.
+
+#### MapBloc (`lib/features/map_layers/presentation/bloc/map_bloc.dart`)
+
+Owns the MapLibre camera and overlay state shared across all screens that embed the map widget.
+
+```dart
+class MapState {
+  final LatLng center;
+  final double zoom;
+  final double tilt;         // 0–60°; nav uses 45°
+  final double bearing;
+  final bool isReady;
+  final bool followUser;
+  final List<PolylineModel> polylines;
+  final bool autoFit;
+  final MapSource? source;
+  final List<MapSource> available;
+  final bool loadingSource;
+  final Set<String> enabledDataLayerIds;
+  // Optional style overrides (null = app default):
+  final int? defaultPolylineColorArgb;
+  final double? defaultPolylineWidth;
+  final int? markerFillColorArgb;
+  final int? markerStrokeColorArgb;
+}
+```
+
+#### DeviceCommBloc (`lib/features/device_comm/device_comm_bloc.dart`)
+
+Wraps `DeviceCommunicationService`. Events: `SendRouteToDevice`, `SendMapRegionToDevice`, `SendMapStyleToDevice`, `SendControlCommand`, `MessageReceived`, `ResetDeviceComm`. States: `DeviceCommIdle`, `DeviceCommSending(progress)`, `DeviceCommSuccess`, `DeviceCommError`, `MessageFromDevice`.
+
+#### ThemeCubit (`lib/core/theme/theme_cubit.dart`)
+
+Persists and emits `AppThemeMode` (system / light / dark). Consumed by `MaterialApp` to switch `ThemeData`.
+
+### Domain layer
+
+Entities live in `lib/core/domain/entities/`. Repository interfaces in `lib/core/domain/repositories/`. Concrete implementations are in each feature's `data/` directory and talk to Rust FFI via `package:nav_e/bridge/lib.dart as api`.
+
+| Entity | Key fields |
+|---|---|
+| `GeocodingResult` | `id, label, lat, lon, address?` |
+| `SavedPlace` | `id, label, lat, lon, icon?` |
+| `SavedRoute` | `id, name, waypoints, polyline, distanceM, durationS` |
+| `Trip` | `id, routeId, startedAt, endedAt, distanceM, durationS` |
+| `Device` | `id, name, remoteId, type` |
+| `OfflineRegion` | `id, name, bbox, zoomMin, zoomMax, tileCount` |
+| `MapSource` | `id, name, tileUrl, type` |
+
+### Theme / design system
+
+All UI styling uses tokens from `lib/core/theme/`. Never use raw `Colors.*` in widget build methods.
+
+#### Spacing (`lib/core/theme/spacing.dart`)
+
+8-pt grid constants:
+
+| Token | Value |
+|---|---|
+| `AppSpacing.xs` | 4 |
+| `AppSpacing.sm` | 8 |
+| `AppSpacing.md` | 16 |
+| `AppSpacing.lg` | 24 |
+| `AppSpacing.xl` | 32 |
+| `AppSpacing.xxl` | 48 |
+
+Off-grid values (6, 10, 12, 20, …) are written as literals with an `// off-grid` comment.
+
+#### Colors (`lib/core/theme/colors.dart`)
+
+`AppColors` is a `ThemeExtension` providing semantic tokens beyond `ColorScheme`:
+
+| Token | Purpose |
+|---|---|
+| `success` / `onSuccess` | Positive confirmations |
+| `warning` / `onWarning` | Speed-limit alerts, cautions |
+| `info` / `onInfo` | Informational banners |
+| `disabled` / `onDisabled` | Inactive controls |
+
+Retrieve with: `Theme.of(context).extension<AppColors>()!`
+
+#### Elevation (`lib/core/theme/elevation.dart`)
+
+`AppElevation.level1(shadow)` through `AppElevation.level4(shadow)` return `List<BoxShadow>` following Material 3 guidelines. Pass `colorScheme.shadow` as the tint colour.
+
+#### `app_theme.dart`
+
+Builds `ThemeData` for light and dark modes with Material 3, custom component themes (AppBar, Card, Button, TextField, Badge, SettingsPanel), and `AppColors` registered as a `ThemeExtension`.
+
+### Services
+
+#### `RoutingEngineService` (`lib/core/routing/routing_engine_service.dart`)
+
+Persists the user's preferred routing engine in `SharedPreferences`.
+
+```dart
+enum RoutingEngine { osrm, valhalla, onDevice }
+// Only RoutingEngine.osrm is currently implemented.
+await RoutingEngineService.setDefaultEngine(RoutingEngine.osrm);
+final engine = await RoutingEngineService.getDefaultEngine();
+```
+
+#### `NavSettingsService` (`lib/core/nav/nav_settings_service.dart`)
+
+Persists navigation preferences (voice guidance, speed-limit alerts, etc.) via `SharedPreferences`.
+
+#### `NavNotificationService` (`lib/core/notifications/nav_notification_service.dart`)
+
+Posts local notifications for turn instructions when the app is backgrounded during active navigation.
+
+### Device communication
+
+`DeviceCommunicationService` (`lib/core/device_comm/device_communication_service.dart`) is the single entry point for all BLE data transfer. It accepts a transport abstraction:
+
+| Transport | Class | Notes |
+|---|---|---|
+| BLE | `BleDeviceCommunicationTransport` | Production; uses `flutter_blue_plus` |
+
+Messages are protobuf-encoded (definitions in `lib/core/device_comm/proto/`; generated from `native/nav_protocol`). The service exposes:
+- `sendRoute(remoteId, routeJson, {onProgress})` — streams route JSON over BLE
+- `sendMapRegion(remoteId, regionId, {onProgress})` — streams offline tile region
+- `sendMapStyle(remoteId, mapSourceId)` — sends map source configuration
+- `sendControlCommand(remoteId, ...)` — sends control frames
+- `messageStream` — `Stream<DeviceMessage>` for incoming device messages
+- `getConnectedDeviceIds()` → `List<ConnectedDeviceInfo>`
+
+### FFI bridge
+
+```dart
+import 'package:nav_e/bridge/lib.dart' as api;
+```
+
+`lib/bridge/` is **generated** by `make codegen` from `native/nav_e_ffi/src/lib.rs`. Never edit it manually. Key callable functions:
+
+| Function | Returns | Purpose |
+|---|---|---|
+| `api.initializeDatabase(dbPath)` | `void` | One-time DB setup at startup |
+| `api.getActiveSession()` | `String?` (JSON) | Restore in-progress nav session |
+| `api.startNavigationSession(waypoints, pos)` | `String` (JSON) | Create Rust nav session |
+| `api.updateNavigationPosition(sessionId, lat, lon)` | `String` (JSON) | Feed GPS → nav engine → state |
+| `api.getNavigationState(sessionId)` | `String?` (JSON) | Poll current navigation state |
+| `api.getRouteSteps(sessionId)` | `String` (JSON) | Full step list for turn feed |
+| `api.stopNavigation(sessionId)` | `void` | End session, persist trip |
+| `api.pauseNavigation(sessionId)` | `void` | Pause session |
+| `api.resumeNavigation(sessionId)` | `void` | Resume session |
+| `api.calculateRoute(waypoints, engine)` | `String` (JSON) | OSRM route calculation |
+| `api.saveTrip(...)` | `void` | Persist completed trip |
+
+---
+
+## Features
+
+### `device_comm` — BLE Debug Console
+
+**Pattern:** BLoC (`DeviceCommBloc`)
+**Purpose:** Developer-facing screen for inspecting raw BLE message exchange with connected devices. Not exposed in production navigation flows.
+
+**State shape:** see `DeviceCommBloc` in Core section above.
+
+**Key files:**
+- `lib/features/device_comm/device_comm_bloc.dart`
+- `lib/features/device_comm/presentation/screens/device_comm_debug_screen.dart`
+- `lib/features/device_comm/presentation/bloc/device_comm_events.dart`
+- `lib/features/device_comm/presentation/bloc/device_comm_states.dart`
+
+---
+
+### `device_management` — BLE Device Registry
+
+**Pattern:** BLoC (`DevicesBloc`)
+**Purpose:** Lists paired BLE navigation devices, supports adding and removing devices. Each device can receive routes and offline map regions over BLE.
+
+**State shape:**
+
+```dart
+sealed class DevicesState
+class DeviceInitial      extends DevicesState
+class DeviceLoadInProgress extends DevicesState
+class DeviceLoadSuccess  extends DevicesState { List<Device> devices }
+class DeviceOperationInProgress extends DevicesState
+class DeviceOperationSuccess extends DevicesState { String message; Device? device }
+class DeviceOperationFailure extends DevicesState { String message }
+```
+
+**FFI calls:** `api.getDevices()`, `api.addDevice(...)`, `api.removeDevice(id)`
+
+**Key files:**
+- `lib/features/device_management/bloc/devices_bloc.dart`
+- `lib/features/device_management/device_management_screen.dart`
+- `lib/features/device_management/add_device_screen.dart`
+- `lib/features/device_management/data/device_repository_rust.dart`
+
+---
+
+### `home` — Explore Map Shell
+
+**Pattern:** StatefulWidget (no dedicated BLoC; reads global `MapBloc`, `LocationBloc`, `PreviewCubit`)
+**Purpose:** The main explore view with a MapLibre map, a floating search bar, a side-menu drawer, and a location-preview bottom sheet. Acts as a compositing layer for `map_layers`, `location_preview`, and `search` overlays.
+
+**Key files:**
+- `lib/features/home/home_screen.dart`
+- `lib/features/home/home_view.dart`
+- `lib/features/home/dashboard/home_dashboard_screen.dart`
+- `lib/features/home/widgets/search_overlay_widget.dart`
+- `lib/features/home/widgets/route_preview_widget.dart`
+- `lib/features/home/utils/route_params_handler.dart`
+
+---
+
+### `location_preview` — Tapped-Point Detail
+
+**Pattern:** Cubit (`PreviewCubit`)
+**Purpose:** Shows a bottom sheet with details about a map-tapped coordinate or a resolved geocoding result. Provides quick actions (save place, navigate here, route from here).
+
+**State shape:**
+
+```dart
+sealed class PreviewState
+class PreviewIdle               extends PreviewState
+class LocationPreviewShowing    extends PreviewState { GeocodingResult result }
+```
+
+**API:**
+
+```dart
+context.read<PreviewCubit>().showCoords(lat: ..., lon: ..., label: ...);
+context.read<PreviewCubit>().showResolved(result);
+context.read<PreviewCubit>().hide();
+```
+
+**Key files:**
+- `lib/features/location_preview/cubit/preview_cubit.dart`
+- `lib/features/location_preview/location_preview_widget.dart`
+- `lib/features/location_preview/data/preview_params_mapper.dart`
+
+---
+
+### `map_layers` — Map Rendering & Camera
+
+**Pattern:** BLoC (`MapBloc`)
+**Purpose:** Owns the MapLibre widget lifecycle, camera control (follow-user, tilt, bearing, auto-fit), polyline overlays, map source switching, and data layer toggles (e.g. parking overlay). All other features write to `MapBloc` and read the shared `MapState`.
+
+**Key events:** `MapReady`, `MoveTo`, `SetFollowUser`, `SetPolylines`, `SetTilt`, `SetBearing`, `ResetBearing`, `SetMapSource`, `ToggleDataLayer`, `SetStyleOverrides`
+
+**Key files:**
+- `lib/features/map_layers/presentation/bloc/map_bloc.dart`
+- `lib/features/map_layers/presentation/map_widget.dart`
+- `lib/features/map_layers/presentation/map_adapters/maplibre_widget.dart`
+- `lib/features/map_layers/presentation/map_adapters/maplibre_map_adapter.dart`
+- `lib/features/map_layers/data/data_layer_registry.dart`
+- `lib/features/map_layers/models/polyline_model.dart`
+
+---
+
+### `nav` — Active Turn-by-Turn Navigation
+
+**Pattern:** BLoC (`NavBloc`)
+**Purpose:** Manages an active navigation session from start to finish. Feeds GPS positions into the Rust nav engine, receives `NavigationStateDto` back (snapped position, next cue, remaining distance/time, constraint alerts), debounces off-route detection (3-strike threshold, 30 s cooldown), and triggers automatic rerouting.
+
+**Events:**
+
+| Event | Trigger |
+|---|---|
+| `NavStart(routeId, routePoints, sessionId?)` | User confirms route in `PlanRouteScreen` |
+| `NavStop({completed})` | User taps finish or route completes |
+| `PositionUpdate(position, speed?, bearing?)` | `LocationBloc` stream |
+| `CueFromNative(cue)` | Rust nav engine pushes a new turn instruction |
+| `SetFollowMode(follow)` | User taps recenter FAB |
+| `SetTurnFeed(feed)` | Full step list refresh from `getRouteSteps` |
+| `NavPause` | User taps pause button |
+| `NavResume` | User taps resume button |
+| `NavReroute` | Off-route debouncer fires |
+
+**State shape:**
+
+```dart
+class NavState {
+  final bool active;
+  final String? routeId;
+  final String? sessionId;          // Rust session ID for FFI calls
+  final double? remainingDistanceM;
+  final int? remainingSeconds;
+  final NavCue? nextCue;
+  final List<LatLng> progressPolyline;
+  final List<NavCue> turnFeed;
+  final double? speed;
+  final LatLng? lastPosition;
+  final bool following;
+  final bool lightweightMode;
+  final DateTime? startedAt;
+  final double? distanceM;
+  final int? durationS;
+  final String? destinationLabel;
+  final bool completedWithSummary;
+  final bool isOffRoute;
+  final bool isPaused;
+  final bool isRerouting;
+  final List<String> constraintAlerts;  // e.g. speed limit warnings
+  final LatLng? snappedPosition;        // route-snapped GPS for map puck
+}
+```
+
+**FFI calls:** `startNavigationSession`, `updateNavigationPosition`, `getRouteSteps`, `stopNavigation`, `pauseNavigation`, `resumeNavigation`, `calculateRoute` (reroute), `saveTrip`
+
+**Key files:**
+- `lib/features/nav/bloc/nav_bloc.dart`
+- `lib/features/nav/bloc/nav_event.dart`
+- `lib/features/nav/bloc/nav_state.dart`
+- `lib/features/nav/ui/active_nav_screen.dart`
+- `lib/features/nav/ui/nav_banner.dart`
+- `lib/features/nav/ui/route_finish_screen.dart`
+- `lib/features/nav/models/nav_models.dart`
+
+---
+
+### `offline_maps` — Tile Region Manager
+
+**Pattern:** Cubit (`OfflineMapsCubit`)
+**Purpose:** Lists, downloads, and deletes offline map tile regions. Download iterates over predefined zoom levels and reports per-tile progress. A local tile server (`LocalTileServer`) serves cached tiles to the map renderer.
+
+**State shape:**
+
+```dart
+enum OfflineMapsStatus { initial, loading, loaded, downloading, error }
+
+class OfflineMapsState {
+  final OfflineMapsStatus status;
+  final List<OfflineRegion> regions;
+  final String? errorMessage;
+  final int downloadProgress;       // tiles downloaded so far
+  final int downloadTotal;          // total tiles for this zoom level
+  final int downloadZoom;           // current zoom level being fetched
+  final String? downloadingRegionName;
+}
+```
+
+**FFI calls:** `api.listOfflineRegions()`, `api.downloadOfflineRegion(...)`, `api.deleteOfflineRegion(id)`
+
+**Key files:**
+- `lib/features/offline_maps/cubit/offline_maps_cubit.dart`
+- `lib/features/offline_maps/cubit/offline_maps_state.dart`
+- `lib/features/offline_maps/presentation/offline_maps_screen.dart`
+- `lib/features/offline_maps/presentation/widgets/download_region_sheet.dart`
+- `lib/features/offline_maps/data/local_tile_server.dart`
+- `lib/features/offline_maps/data/predefined_regions.dart`
+
+---
+
+### `plan` — Quick Navigation Start
+
+**Pattern:** StatelessWidget / StatefulWidget (reads global state)
+**Purpose:** The "Plan" tab of the bottom navigation shell. Provides a quick-start UI with recent searches, saved places shortcuts, and a "Go" button that transitions to `PlanRouteScreen` with a prefilled destination.
+
+**Key files:**
+- `lib/features/plan/plan_screen.dart`
+
+---
+
+### `plan_route` — Route Planning & Preview
+
+**Pattern:** StatefulWidget + inline route calculation (no dedicated BLoC)
+**Purpose:** Full route planning screen. Users select a start point (GPS, map centre, or manual pick), select a destination (passed as `GeocodingResult` via router `extra`), choose a routing engine, and preview the resulting polyline on the map. Debounced recalculation (400 ms) fires on any input change. Users can save the route or start navigation.
+
+**FFI calls:** `api.calculateRoute(waypoints, engine)` → JSON with polyline, distanceM, durationS
+
+**Key files:**
+- `lib/features/plan_route/plan_route_screen.dart`
+- `lib/features/plan_route/widgets/route_top_panel.dart`
+- `lib/features/plan_route/widgets/route_bottom_sheet.dart`
+- `lib/features/plan_route/widgets/plan_route_map.dart`
+
+---
+
+### `profile` — User Profile
+
+**Pattern:** StatelessWidget
+**Purpose:** Displays user account information and provides navigation links to settings, trip history, saved places, and saved routes. Entry point for account-level management.
+
+**Key files:**
+- `lib/features/profile/profile_screen.dart`
+
+---
+
+### `saved_places` — Bookmarked Locations
+
+**Pattern:** Cubit (`SavedPlacesCubit`)
+**Purpose:** CRUD for user-bookmarked locations. Loaded at startup and kept live so place counts are reflected across the app.
+
+**State shape:**
+
+```dart
+sealed class SavedPlacesState
+class SavedPlacesInitial extends SavedPlacesState
+class SavedPlacesLoading extends SavedPlacesState
+class SavedPlacesLoaded  extends SavedPlacesState { List<SavedPlace> places }
+class SavedPlacesError   extends SavedPlacesState { String message }
+```
+
+**FFI calls:** `api.getSavedPlaces()`, `api.savePlace(...)`, `api.deletePlace(id)`
+
+**Key files:**
+- `lib/features/saved_places/cubit/saved_places_cubit.dart`
+- `lib/features/saved_places/cubit/saved_places_state.dart`
+- `lib/features/saved_places/saved_places_screen.dart`
+- `lib/features/saved_places/data/saved_places_repository_rust.dart`
+
+---
+
+### `saved_routes` — Route Library
+
+**Pattern:** Cubit (`SavedRoutesCubit`)
+**Purpose:** Lists routes saved from `PlanRouteScreen` or imported as GPX files. Each `SavedRoute` is paired with a `RouteEnrichment` (computed metadata such as elevation gain) on load. GPX import preview is handled by `ImportPreviewScreen` before persisting.
+
+**State shape:**
+
+```dart
+sealed class SavedRoutesState
+class SavedRoutesInitial extends SavedRoutesState
+class SavedRoutesLoading extends SavedRoutesState
+class SavedRoutesLoaded  extends SavedRoutesState {
+  List<SavedRoute> routes;
+  List<RouteEnrichment> enrichments;
+}
+class SavedRoutesError   extends SavedRoutesState { String message }
+```
+
+**FFI calls:** `api.getSavedRoutes()`, `api.saveRoute(...)`, `api.deleteRoute(id)`, `api.importGpx(xml)`
+
+**Key files:**
+- `lib/features/saved_routes/cubit/saved_routes_cubit.dart`
+- `lib/features/saved_routes/cubit/saved_routes_state.dart`
+- `lib/features/saved_routes/saved_routes_screen.dart`
+- `lib/features/saved_routes/import_preview_screen.dart`
+- `lib/features/saved_routes/route_enrichment.dart`
+- `lib/features/saved_routes/data/saved_routes_repository_rust.dart`
+
+---
+
+### `search` — Geocoding
+
+**Pattern:** BLoC (`SearchBloc`)
+**Purpose:** Full-screen search with debounced geocoding via Nominatim (through the Rust `nav_route` crate), search history, and result selection. Selected `GeocodingResult` is passed as `extra` to the router when navigating to `PlanRouteScreen`.
+
+**State shape:**
+
+```dart
+class SearchState {
+  final bool loading;
+  final List<GeocodingResult> results;
+  final List<GeocodingResult> history;
+  final String? error;
+  final GeocodingResult? selected;
+}
+```
+
+**FFI calls:** `api.geocode(query)` → JSON list of `GeocodingResult`
+
+**Key files:**
+- `lib/features/search/bloc/search_bloc.dart`
+- `lib/features/search/bloc/search_event.dart`
+- `lib/features/search/bloc/search_state.dart`
+- `lib/features/search/search_screen.dart`
+- `lib/features/search/data/geocoding_repository_frb_typed_impl.dart`
+
+---
+
+### `settings` — App Settings
+
+**Pattern:** StatelessWidget (reads service singletons + `ThemeCubit` + `OfflineMapsCubit`)
+**Purpose:** Aggregates all user preferences across themed sections:
+
+| Section | Widget | Controls |
+|---|---|---|
+| Theme | `ThemeSettingsSection` | Light / Dark / System toggle |
+| Routing engine | `RoutingEngineSettingsSection` | OSRM / Valhalla / On-Device (OSRM only active) |
+| Navigation | `NavigationSettingsSection` | Voice guidance, speed alerts |
+| Map styling | `MapStylingSection` | Map source picker |
+| Offline maps | `OfflineMapsSectionWidget` | Quick link to offline map manager |
+| Trip history | `TripHistorySettingsSection` | Clear history |
+| About | `AboutSection` | Version, licenses |
+
+**Key files:**
+- `lib/features/settings/settings_screen.dart`
+- `lib/features/settings/widgets/` (one file per section)
+
+---
+
+### `trip_history` — Completed Trips
+
+**Pattern:** Cubit (`TripHistoryCubit`)
+**Purpose:** Lists completed navigation sessions. Each `Trip` can be opened in `TripDetailScreen` for a replay of the route polyline.
+
+**State shape:**
+
+```dart
+abstract class TripHistoryState
+class TripHistoryInitial extends TripHistoryState
+class TripHistoryLoading extends TripHistoryState
+class TripHistoryLoaded  extends TripHistoryState { List<Trip> trips }
+class TripHistoryError   extends TripHistoryState { String message }
+```
+
+**FFI calls:** `api.getTrips()`, `api.deleteTrip(id)`
+
+**Key files:**
+- `lib/features/trip_history/cubit/trip_history_cubit.dart`
+- `lib/features/trip_history/cubit/trip_history_state.dart`
+- `lib/features/trip_history/trip_history_screen.dart`
+- `lib/features/trip_history/trip_detail_screen.dart`
+- `lib/features/trip_history/data/trip_repository_rust.dart`
+
+---
+
+## Data flows
+
+### 1. End-to-end navigation
+
+```
+User taps "Go" in PlanScreen / SavedRoutes
+    │
+    ▼
+SearchScreen (if destination not yet set)
+  SearchBloc calls api.geocode(query)
+  User selects GeocodingResult
+    │
+    ▼
+PlanRouteScreen
+  api.calculateRoute(waypoints, engine="osrm")
+  MapBloc ← SetPolylines([routePolyline])
+  MapBloc ← SetTilt(45), SetFollowUser(true)
+  User taps "Start Navigation"
+    │
+    ▼
+api.startNavigationSession(waypoints, currentPosition)
+  → returns sessionId (JSON)
+NavBloc ← NavStart(routeId, routePoints, sessionId: sessionId)
+  → push /active-nav
+    │
+    ▼ (every GPS tick from LocationBloc)
+NavBloc ← PositionUpdate(position, speed, bearing)
+  api.updateNavigationPosition(sessionId, lat, lon)
+  → NavigationStateDto { snappedPosition, nextInstruction,
+                         distanceToNextM, distanceRemainingM,
+                         etaSeconds, offRoute, constraintAlerts }
+  NavBloc emits NavState (nextCue, remainingDistanceM, …)
+  MapBloc ← MoveTo(snappedPosition) [camera follow]
+  NavBanner redraws turn instruction + distance
+    │
+    ▼ (off-route: 3 consecutive ticks)
+NavBloc ← NavReroute
+  api.calculateRoute(from=snappedPosition, to=destination)
+  api.startNavigationSession(…) [new sessionId]
+  NavBloc updates sessionId, polyline
+    │
+    ▼ (destination reached or user taps Finish)
+NavBloc ← NavStop(completed: true)
+  api.stopNavigation(sessionId)
+  api.saveTrip(…)
+  TripHistoryCubit reloads
+  router.push('/route-finish', extra: RouteFinishPayload)
+```
+
+### 2. Offline map download
+
+```
+User opens OfflineMapsScreen
+  OfflineMapsCubit.load() → api.listOfflineRegions()
+  renders list of OfflineRegion tiles
+    │
+    ▼ (user taps "Download Region")
+DownloadRegionSheet / SelectRegionSheet displayed
+  User selects predefined region (PredefinedRegions.all)
+    │
+    ▼
+OfflineMapsCubit.download(region)
+  emits OfflineMapsState(status: downloading, downloadingRegionName: ...)
+  for each zoom level:
+    api.downloadOfflineRegion(id, bbox, zoom,
+        onProgress: (done, total) {
+          emit state.copyWith(downloadProgress: done, downloadTotal: total,
+                              downloadZoom: zoom);
+        })
+  emits status: loaded
+  LocalTileServer registers new region for offline map rendering
+```
+
+### 3. Settings → routing engine change
+
+```
+User opens SettingsScreen → RoutingEngineSettingsSection
+  reads current engine via RoutingEngineService.getDefaultEngine()
+  renders radio list (OSRM active; Valhalla/On-Device show "Coming soon")
+    │
+    ▼ (user selects OSRM)
+RoutingEngineService.setDefaultEngine(RoutingEngine.osrm)
+  SharedPreferences.setString('routing_engine', 'osrm')
+    │
+    ▼ (next route calculation in PlanRouteScreen)
+api.calculateRoute(waypoints, engine: 'osrm')
+```
+
+---
+
+## App layout
+
+```
+lib/
+├── main.dart                          # App entry point; DB init, providers, session restore
+├── app/
+│   ├── app_nav.dart                   # Navigation helpers
+│   ├── app_router.dart                # GoRouter: shell + all named routes
+│   └── app_shell.dart                 # StatefulShellRoute scaffold
+├── bridge/                            # GENERATED — do not edit
+│   ├── frb_generated.dart
+│   ├── frb_generated.io.dart
+│   └── lib.dart                       # Public FFI surface (import as api)
+├── core/
+│   ├── bloc/
+│   │   ├── location_bloc.dart
+│   │   └── bluetooth/                 # BluetoothBloc + events/states
+│   ├── constants/
+│   │   └── app_version.dart
+│   ├── data/
+│   │   ├── map_adapter.dart
+│   │   └── remote/                    # Remote map source configs
+│   ├── device_comm/
+│   │   ├── device_communication_service.dart
+│   │   ├── ble_device_comm_transport.dart
+│   │   └── proto/                     # Dart protobuf generated files
+│   ├── domain/
+│   │   ├── entities/                  # GeocodingResult, Device, Trip, …
+│   │   ├── extensions/
+│   │   └── repositories/              # Abstract repository interfaces
+│   ├── nav/
+│   │   └── nav_settings_service.dart
+│   ├── notifications/
+│   │   └── nav_notification_service.dart
+│   ├── platform/
+│   │   └── route_import_channel.dart  # GPX import platform channel
+│   ├── routing/
+│   │   └── routing_engine_service.dart
+│   └── theme/
+│       ├── app_theme.dart             # ThemeData builders (light + dark)
+│       ├── colors.dart                # AppColors ThemeExtension
+│       ├── elevation.dart             # AppElevation.level1–4
+│       ├── spacing.dart               # AppSpacing constants
+│       ├── palette.dart               # Raw colour palette (theme use only)
+│       ├── typography.dart            # TextTheme definitions
+│       ├── theme_cubit.dart
+│       └── components/
+│           ├── appbar.dart
+│           ├── badges.dart
+│           ├── buttons.dart
+│           ├── cards.dart
+│           ├── decorations.dart
+│           ├── inputs.dart
+│           └── settings_panel.dart
+├── features/
+│   ├── device_comm/                   # BLE debug console
+│   ├── device_management/             # BLE device registry
+│   ├── home/                          # Explore map shell + overlays
+│   ├── location_preview/              # Tapped-point detail sheet
+│   ├── map_layers/                    # MapBloc + MapLibre widget
+│   ├── nav/                           # Active turn-by-turn navigation
+│   ├── offline_maps/                  # Tile region download/manage
+│   ├── plan/                          # Quick navigation start tab
+│   ├── plan_route/                    # Route planning + preview
+│   ├── profile/                       # User profile tab
+│   ├── saved_places/                  # Bookmarked locations
+│   ├── saved_routes/                  # Route library + GPX import
+│   ├── search/                        # Geocoding search screen
+│   ├── settings/                      # App settings
+│   └── trip_history/                  # Completed trips
+└── widgets/                           # Shared leaf widgets
+    ├── draggable_fab_widget.dart
+    ├── search_bar_widget.dart
+    ├── side_menu_drawer.dart
+    ├── user_location_marker.dart
+    └── subtext.widget.dart
+```

--- a/docs/rust/nav_engine.md
+++ b/docs/rust/nav_engine.md
@@ -1,0 +1,275 @@
+# nav_engine
+
+Runtime turn-by-turn navigation engine — pure logic, no I/O.
+
+This crate takes a `nav_ir::Route` and a stream of GPS position updates and returns structured `NavigationState` snapshots describing the driver's progress. It handles step advancement, off-route detection, ETA calculation, polyline snapping, and constraint alerts with no async, no FFI, and no network dependencies.
+
+## Architecture
+
+`nav_engine` is a leaf crate in the dependency tree:
+
+```
+nav_e_ffi
+  └── nav_core            ← session persistence, FFI wiring
+        └── nav_engine    ← this crate (pure navigation logic)
+              └── nav_ir  ← route format (Route, Coordinate, Instruction)
+```
+
+`nav_core` creates and drives a `NavigationEngine` instance per active session. The resulting `NavigationState` is serialized to JSON by `nav_e_ffi` before being returned to Dart.
+
+## Quick start
+
+```rust
+use nav_engine::NavigationEngine;
+use nav_ir::Coordinate;
+
+// New session
+let mut engine = NavigationEngine::new(route);
+
+// Each GPS fix
+let state = engine.update_position(
+    Coordinate { latitude: 51.5074, longitude: -0.1278 },
+    Some(13.8), // speed in m/s (optional)
+);
+
+println!("Step {}, {:.0}m to next turn", state.current_step, state.distance_to_next_m);
+println!("Off route: {}", state.off_route.is_off_route);
+
+// Resumed session (restore step + distance from persisted state)
+let mut engine = NavigationEngine::new_with_state(route, saved_step, saved_distance_m);
+```
+
+## Public API
+
+### `NavigationEngine`
+
+The main entry point. Owns the decoded route polyline and all derived turn instructions.
+
+```rust
+/// Create a fresh engine starting at step 0.
+pub fn new(route: Route) -> Self
+
+/// Restore engine to a previously saved step and distance (session resume).
+pub fn new_with_state(route: Route, current_step: usize, distance_traveled_m: f64) -> Self
+
+/// Process a GPS fix and return the current navigation state.
+/// speed_mps: optional GPS speed used for ETA; falls back to route duration then 40 km/h.
+pub fn update_position(&mut self, pos: Coordinate, speed_mps: Option<f64>) -> NavigationState
+
+/// Index of the current instruction step.
+pub fn current_step(&self) -> usize
+
+/// Total distance traveled so far (meters).
+pub fn distance_traveled_m(&self) -> f64
+
+/// All derived instructions for this route (useful for turn-list display).
+pub fn instructions(&self) -> &[DerivedInstruction]
+```
+
+---
+
+### `NavigationState`
+
+The output of every `update_position` call.
+
+```rust
+pub struct NavigationState {
+    /// Index into the instructions array for the step the driver is currently on.
+    pub current_step: usize,
+    /// Full instruction for the current step.
+    pub current_instruction: DerivedInstruction,
+    /// Next upcoming instruction, if any.
+    pub next_instruction: Option<DerivedInstruction>,
+    /// Distance from snapped position to the next instruction (meters).
+    pub distance_to_next_m: f64,
+    /// Total remaining distance to destination (meters).
+    pub distance_remaining_m: f64,
+    /// Estimated time to arrival (seconds).
+    pub eta_seconds: u64,
+    /// Off-route status.
+    pub off_route: OffRouteStatus,
+    /// Active constraint alerts (speed limits, highway/toll flags).
+    pub constraint_alerts: Vec<ConstraintAlert>,
+    /// GPS position projected onto the nearest polyline segment.
+    pub snapped_position: Coordinate,
+}
+```
+
+---
+
+### `DerivedInstruction`
+
+A single turn instruction derived from the route polyline.
+
+```rust
+pub struct DerivedInstruction {
+    pub kind: DerivedInstructionKind,
+    /// Index of the corresponding vertex in the decoded polyline.
+    pub vertex_index: usize,
+    /// Distance from this instruction to the next (meters).
+    pub distance_to_next_m: f64,
+    pub street_name: Option<String>,
+}
+```
+
+---
+
+### `DerivedInstructionKind`
+
+```rust
+pub enum DerivedInstructionKind {
+    Depart,
+    SharpLeft,
+    TurnLeft,
+    SlightLeft,
+    Continue,
+    SlightRight,
+    TurnRight,
+    SharpRight,
+    Arrive,
+}
+```
+
+Each variant implements `as_str() -> &'static str` for display.
+
+**Turn angle thresholds** (bearing delta from previous segment):
+
+| Delta | Kind |
+|---|---|
+| > 120° | `SharpRight` |
+| ≥ 45° | `TurnRight` |
+| ≥ 25° | `SlightRight` |
+| −25° to 25° | `Continue` |
+| −45° to −25° | `SlightLeft` |
+| −120° to −45° | `TurnLeft` |
+| ≤ −120° | `SharpLeft` |
+
+---
+
+### `OffRouteStatus`
+
+```rust
+pub struct OffRouteStatus {
+    pub is_off_route: bool,
+    /// Perpendicular distance from GPS position to the nearest polyline segment (meters).
+    pub distance_from_route_m: f64,
+    /// Re-routing policy sourced from the route's policies (e.g. Recalculate, Warn).
+    pub behavior: nav_ir::OffRouteBehavior,
+}
+```
+
+Off-route is triggered when `distance_from_route_m > 50.0`.
+
+---
+
+### `ConstraintAlert`
+
+```rust
+pub enum ConstraintAlert {
+    SpeedLimit { max_kmh: u32 },
+    AvoidHighway,
+    AvoidToll,
+}
+```
+
+Alerts are derived from the route's constraint metadata and included in every `NavigationState`.
+
+## Step advancement
+
+Steps advance automatically as the GPS position moves forward along the polyline. On each `update_position` call the engine finds the nearest polyline vertex to the current GPS fix, then advances `current_step` as long as the nearest vertex has passed the next instruction's `vertex_index`:
+
+```
+while current_step + 1 < instructions.len()
+    && nearest_vertex >= instructions[current_step + 1].vertex_index
+{
+    current_step += 1;
+}
+```
+
+This means the engine tolerates imprecise GPS — even if a position update is reported late, the correct step is recovered on the next fix.
+
+## Off-route detection
+
+`distance_to_polyline` projects the GPS position onto every segment of the decoded polyline and returns the minimum perpendicular distance, the index of the nearest vertex, and the actual projected (snapped) coordinate on that segment.
+
+Off-route fires when that distance exceeds **50 m** (`OFF_ROUTE_THRESHOLD_M`). The `OffRouteBehavior` policy embedded in the route controls what the caller should do (recalculate, warn, etc.).
+
+## ETA calculation
+
+ETA priority order:
+
+1. **Known GPS speed** (`speed_mps` argument) — `remaining_m / speed_mps`
+2. **Route duration estimate** — scale `estimated_duration_s` proportionally by `remaining_m / total_distance_m`
+3. **Fallback** — assume 40 km/h (11.111 m/s)
+
+## Instruction derivation
+
+`derive_instructions(vertices, existing)` builds the full instruction list:
+
+1. Pre-existing `nav_ir::Instruction` items from the route are used directly.
+2. Remaining polyline vertices with a bearing delta ≥ **25°** (`MIN_TURN_DEGREES`) generate a new `DerivedInstruction`.
+3. Instructions closer than **30 m** (`MIN_INSTRUCTION_DISTANCE_M`) to the previous one are filtered out, keeping the higher-severity turn.
+4. A `Depart` instruction is always prepended; an `Arrive` is always appended.
+
+Turn severity used for filtering:
+
+| Rank | Kinds |
+|---|---|
+| 5 (always kept) | `Depart`, `Arrive` |
+| 4 | `SharpLeft`, `SharpRight` |
+| 3 | `TurnLeft`, `TurnRight` |
+| 2 | `SlightLeft`, `SlightRight` |
+| 1 | `Continue` |
+
+## Constants
+
+| Constant | Value | Description |
+|---|---|---|
+| `OFF_ROUTE_THRESHOLD_M` | 50.0 m | Distance beyond which the driver is considered off-route |
+| `MIN_TURN_DEGREES` | 25.0° | Minimum bearing delta to generate a turn instruction from a polyline vertex |
+| `MIN_INSTRUCTION_DISTANCE_M` | 30.0 m | Minimum distance between consecutive instructions |
+| Default ETA speed | 11.111 m/s | Fallback speed (40 km/h) when no GPS speed or route duration is available |
+| Earth radius `R` | 6,371,000 m | Used in haversine distance calculations |
+
+## Utility functions
+
+These are public and can be used independently:
+
+```rust
+// derive_instructions module
+pub fn haversine_distance(a: Coordinate, b: Coordinate) -> f64;
+pub fn bearing(from: Coordinate, to: Coordinate) -> f64;
+pub fn derive_instructions(vertices: &[Coordinate], existing: &[Instruction]) -> Vec<DerivedInstruction>;
+
+// progress module
+pub fn remaining_distance(vertices: &[Coordinate], from_vertex: usize) -> f64;
+pub fn estimate_eta(remaining_m: f64, speed_mps: Option<f64>, route_duration_s: Option<u64>, total_distance_m: f64) -> u64;
+
+// off_route module
+pub fn distance_to_polyline(pos: Coordinate, vertices: &[Coordinate]) -> (f64, usize, Coordinate);
+//                                                                          ^dist  ^vertex  ^snapped
+```
+
+## Dependencies
+
+```toml
+nav_ir   = { path = "../nav_ir" }
+polyline = "0.11"   # Google encoded polyline decoding
+geo-types = "0.7"   # Geographic coordinate types
+```
+
+No async runtime, no network, no FFI — safe to test in isolation.
+
+## Crate layout
+
+```
+native/nav_engine/
+├── Cargo.toml
+└── src/
+    ├── lib.rs                  # Public re-exports
+    ├── engine.rs               # NavigationEngine — main state machine
+    ├── types.rs                # NavigationState, DerivedInstruction, ConstraintAlert, OffRouteStatus
+    ├── derive_instructions.rs  # Turn derivation, haversine, bearing
+    ├── progress.rs             # Remaining distance, ETA
+    └── off_route.rs            # Polyline distance + snapping
+```

--- a/docs/rust/nav_route.md
+++ b/docs/rust/nav_route.md
@@ -1,0 +1,187 @@
+# nav_route
+
+HTTP routing and geocoding service implementations for `nav_core` ports.
+
+This crate is the adapter layer between `nav_core`'s port interfaces and external HTTP services (OSRM for routing, Nominatim for geocoding). It isolates all HTTP client dependencies so that `nav_core` itself remains free of network concerns.
+
+## Architecture
+
+`nav_route` sits in the infrastructure layer of the hexagonal architecture:
+
+```
+nav_e_ffi
+  └── nav_route          ← this crate (HTTP adapters)
+        ├── OsrmRouteService       implements nav_core::RouteService
+        └── NominatimGeocodingService  implements nav_core::GeocodingService
+  └── nav_core           ← port interfaces + domain logic
+  └── nav_ir             ← canonical route format (NavIrRoute)
+```
+
+`nav_e_ffi` constructs the services, wraps them in `Arc<T>`, and injects them into `nav_core` via `initialize_database()`. Neither `nav_core` nor `nav_ir` depend on `reqwest` directly.
+
+## Features
+
+| Feature | Default | Description |
+|---|---|---|
+| `osrm` | ✓ | OSRM routing via `OsrmRouteService` |
+| `nominatim` | ✓ | Nominatim geocoding via `NominatimGeocodingService` |
+
+Both features are enabled by default. Disable them individually if you only need one service or are substituting your own implementation.
+
+```toml
+# Both services (default)
+nav_route = { path = "../nav_route" }
+
+# Routing only
+nav_route = { path = "../nav_route", default-features = false, features = ["osrm"] }
+```
+
+## Services
+
+### `OsrmRouteService`
+
+Implements `nav_core::RouteService` using the [OSRM](http://project-osrm.org/) HTTP API.
+
+```rust
+use nav_route::OsrmRouteService;
+
+let service = OsrmRouteService::new(
+    "https://router.project-osrm.org".to_string(),
+);
+```
+
+**Constructor**
+
+```rust
+pub fn new(base_url: String) -> Self
+```
+
+Creates a service pointed at the given OSRM base URL. A default `reqwest::Client` is constructed internally with a 10-second request timeout.
+
+**Trait methods (via `nav_core::RouteService`)**
+
+```rust
+async fn calculate_route(
+    &self,
+    waypoints: Vec<nav_core::Position>,
+) -> anyhow::Result<NavIrRoute>
+
+async fn recalculate_from_position(
+    &self,
+    route: &NavIrRoute,
+    current_position: nav_core::Position,
+) -> anyhow::Result<NavIrRoute>
+```
+
+**HTTP details**
+
+- Endpoint: `GET {base_url}/route/v1/driving/{lon,lat;lon,lat;...}`
+- Query parameters: `overview=full&geometries=polyline`
+- Response is passed directly to `nav_ir::normalize_osrm()` which converts it to a `NavIrRoute`
+
+---
+
+### `NominatimGeocodingService`
+
+Implements `nav_core::GeocodingService` using the [Nominatim](https://nominatim.org/) (OpenStreetMap) geocoding API.
+
+```rust
+use nav_route::NominatimGeocodingService;
+
+let service = NominatimGeocodingService::new(
+    "https://nominatim.openstreetmap.org".to_string(),
+);
+```
+
+A type alias `PhotonGeocodingService` is also exported for backward compatibility — it is the same type.
+
+**Constructor**
+
+```rust
+pub fn new(base_url: String) -> Self
+```
+
+Creates a service pointed at the given Nominatim base URL. A `reqwest::Client` is built with the user-agent `"NavE Navigation App/1.0"` as required by the Nominatim usage policy.
+
+**Trait methods (via `nav_core::GeocodingService`)**
+
+```rust
+async fn geocode(
+    &self,
+    address: &str,
+    limit: Option<u32>,
+) -> anyhow::Result<Vec<GeocodingSearchResult>>
+
+async fn reverse_geocode(
+    &self,
+    position: Position,
+) -> anyhow::Result<String>
+```
+
+**HTTP details**
+
+- Forward geocode: `GET {base_url}/search?q={encoded_query}&format=json&limit={n}&addressdetails=1`
+  - Default limit: 10 results when `None` is passed
+  - Address query is URL-encoded with `urlencoding::encode()`
+- Reverse geocode: `GET {base_url}/reverse?lat={lat}&lon={lon}&format=json`
+  - Returns a human-readable address string
+  - Fallback: returns `"{lat:.6}, {lon:.6}"` if address parsing fails
+
+## Initialization (in `nav_e_ffi`)
+
+```rust
+use std::sync::Arc;
+
+let route_service = Arc::new(nav_route::OsrmRouteService::new(
+    "https://router.project-osrm.org".to_string(),
+));
+let geocoding_service = Arc::new(nav_route::NominatimGeocodingService::new(
+    "https://nominatim.openstreetmap.org".to_string(),
+));
+
+nav_core::api::initialize_database(db_path, route_service, geocoding_service).await?;
+```
+
+Both `Arc<OsrmRouteService>` and `Arc<NominatimGeocodingService>` satisfy the `Send + Sync` bounds required by `nav_core`'s port traits.
+
+## Error Handling
+
+All public methods return `anyhow::Result<T>`. Errors include context messages for diagnosis:
+
+| Service | Error | Cause |
+|---|---|---|
+| OSRM | `"Failed to send OSRM request"` | Network / connectivity |
+| OSRM | `"OSRM returned error status: {body}"` | Non-2xx HTTP response |
+| OSRM | `"Failed to read OSRM response body"` | Response body unreadable |
+| OSRM | `"OSRM normalization failed: {e}"` | `nav_ir::normalize_osrm()` rejected the response |
+| Nominatim | `"Failed to send geocoding request"` | Network / connectivity |
+| Nominatim | `"Failed to parse geocoding response"` | JSON deserialization failed |
+
+## Dependencies
+
+```toml
+nav_core    = { path = "../nav_core" }
+nav_ir      = { path = "../nav_ir" }
+anyhow      = "1"
+async-trait = "0.1"
+serde_json  = "1"
+
+# Optional (feature-gated)
+reqwest     = { version = "0.12", features = ["json", "gzip", "rustls-tls"] }
+urlencoding = "2"
+```
+
+`reqwest` is built with `rustls-tls` (no native TLS dependency) and gzip response decompression enabled.
+
+## Crate layout
+
+```
+native/nav_route/
+├── Cargo.toml
+└── src/
+    ├── lib.rs              # Public re-exports
+    ├── osrm/
+    │   └── mod.rs          # OsrmRouteService
+    └── geocoding/
+        └── mod.rs          # NominatimGeocodingService
+```

--- a/lib/features/nav/bloc/nav_bloc.dart
+++ b/lib/features/nav/bloc/nav_bloc.dart
@@ -136,64 +136,50 @@ class NavBloc extends Bloc<NavEvent, NavState> {
     if (sid == null || !state.active) return;
 
     try {
-      final json = await api.updateNavigationPosition(
+      final navState = await api.updateNavigationPosition(
         sessionId: sid,
         latitude: event.position.latitude,
         longitude: event.position.longitude,
       );
-      final Map<String, dynamic> obj = jsonDecode(json) as Map<String, dynamic>;
-      _applyNavState(obj, emit);
+      _applyNavState(navState, emit);
     } catch (_) {
       // FFI not ready or session ended — continue with position-only state
     }
   }
 
-  void _applyNavState(Map<String, dynamic> obj, Emitter<NavState> emit) {
-    final remainingM = (obj['distance_remaining_m'] as num?)?.toDouble();
-    final etaSecs = (obj['eta_seconds'] as num?)?.toInt();
-    final currentInst = obj['current_instruction'] as Map<String, dynamic>?;
-    final nextInst = obj['next_instruction'] as Map<String, dynamic>?;
-    final distFromRoute =
-        (obj['distance_from_route_m'] as num?)?.toDouble() ?? 0.0;
+  void _applyNavState(api.NavigationStateDto navState, Emitter<NavState> emit) {
+    final remainingM = navState.distanceRemainingM;
+    final etaSecs = navState.etaSeconds.toInt();
+    final distFromRoute = navState.distanceFromRouteM;
     final isOffRoute = distFromRoute > _offRouteThresholdM;
-    final snappedLat = (obj['snapped_lat'] as num?)?.toDouble();
-    final snappedLon = (obj['snapped_lon'] as num?)?.toDouble();
-    final snappedPosition = (snappedLat != null && snappedLon != null)
-        ? LatLng(snappedLat, snappedLon)
-        : null;
-    final constraintAlerts =
-        (obj['constraint_alerts'] as List?)
-            ?.map((e) => e.toString())
-            .toList() ??
-        const <String>[];
+    final snappedPosition = LatLng(navState.snappedLat, navState.snappedLon);
+    final constraintAlerts = navState.constraintAlerts;
 
     NavCue? nextCue;
+    final nextInst = navState.nextInstruction;
     if (nextInst != null) {
-      final kind = nextInst['kind']?.toString() ?? 'continue';
-      final distToNext =
-          (nextInst['distance_to_next_m'] as num?)?.toDouble() ?? 0.0;
+      final kind = nextInst.kind;
+      final distToNext = nextInst.distanceToNextM;
       nextCue = NavCue(
         id: 'next_${kind}_${distToNext.toInt()}',
-        instruction: _instructionFor(kind, nextInst['street_name']?.toString()),
+        instruction: _instructionFor(kind, nextInst.streetName),
         distanceToCueM: distToNext,
         distanceToCueText: _formatDistanceText(distToNext),
         location: state.lastPosition ?? const LatLng(0, 0),
         maneuver: kind,
-        streetName: nextInst['street_name']?.toString(),
+        streetName: nextInst.streetName,
       );
-    } else if (currentInst != null) {
-      final kind = currentInst['kind']?.toString() ?? 'continue';
+    } else {
+      final currentInst = navState.currentInstruction;
+      final kind = currentInst.kind;
       nextCue = NavCue(
         id: 'curr_$kind',
-        instruction: _instructionFor(
-          kind,
-          currentInst['street_name']?.toString(),
-        ),
+        instruction: _instructionFor(kind, currentInst.streetName),
         distanceToCueM: 0.0,
         distanceToCueText: '',
         location: state.lastPosition ?? const LatLng(0, 0),
         maneuver: kind,
-        streetName: currentInst['street_name']?.toString(),
+        streetName: currentInst.streetName,
       );
     }
 

--- a/lib/features/nav/bloc/nav_bloc.dart
+++ b/lib/features/nav/bloc/nav_bloc.dart
@@ -136,10 +136,13 @@ class NavBloc extends Bloc<NavEvent, NavState> {
     if (sid == null || !state.active) return;
 
     try {
-      final navState = await api.updateNavigationPosition(
+      final navJson = await api.updateNavigationPosition(
         sessionId: sid,
         latitude: event.position.latitude,
         longitude: event.position.longitude,
+      );
+      final navState = NavigationStateDto.fromJson(
+        jsonDecode(navJson) as Map<String, dynamic>,
       );
       _applyNavState(navState, emit);
     } catch (_) {
@@ -147,9 +150,9 @@ class NavBloc extends Bloc<NavEvent, NavState> {
     }
   }
 
-  void _applyNavState(api.NavigationStateDto navState, Emitter<NavState> emit) {
+  void _applyNavState(NavigationStateDto navState, Emitter<NavState> emit) {
     final remainingM = navState.distanceRemainingM;
-    final etaSecs = navState.etaSeconds.toInt();
+    final etaSecs = navState.etaSeconds;
     final distFromRoute = navState.distanceFromRouteM;
     final isOffRoute = distFromRoute > _offRouteThresholdM;
     final snappedPosition = LatLng(navState.snappedLat, navState.snappedLon);

--- a/lib/features/nav/models/nav_models.dart
+++ b/lib/features/nav/models/nav_models.dart
@@ -1,5 +1,78 @@
 import 'package:latlong2/latlong.dart';
 
+/// Mirrors [native/nav_core `NavigationStateDto`] JSON from FFI (`updateNavigationPosition`).
+class NavigationStateDto {
+  final int currentStep;
+  final DerivedInstructionDto currentInstruction;
+  final DerivedInstructionDto? nextInstruction;
+  final double distanceToNextM;
+  final double distanceRemainingM;
+  final int etaSeconds;
+  final bool isOffRoute;
+  final double distanceFromRouteM;
+  final double snappedLat;
+  final double snappedLon;
+  final List<String> constraintAlerts;
+
+  NavigationStateDto({
+    required this.currentStep,
+    required this.currentInstruction,
+    this.nextInstruction,
+    required this.distanceToNextM,
+    required this.distanceRemainingM,
+    required this.etaSeconds,
+    required this.isOffRoute,
+    required this.distanceFromRouteM,
+    required this.snappedLat,
+    required this.snappedLon,
+    required this.constraintAlerts,
+  });
+
+  factory NavigationStateDto.fromJson(Map<String, dynamic> json) {
+    return NavigationStateDto(
+      currentStep: (json['current_step'] as num).toInt(),
+      currentInstruction: DerivedInstructionDto.fromJson(
+        json['current_instruction'] as Map<String, dynamic>,
+      ),
+      nextInstruction: json['next_instruction'] == null
+          ? null
+          : DerivedInstructionDto.fromJson(
+              json['next_instruction'] as Map<String, dynamic>,
+            ),
+      distanceToNextM: (json['distance_to_next_m'] as num).toDouble(),
+      distanceRemainingM: (json['distance_remaining_m'] as num).toDouble(),
+      etaSeconds: (json['eta_seconds'] as num).toInt(),
+      isOffRoute: json['is_off_route'] as bool,
+      distanceFromRouteM: (json['distance_from_route_m'] as num).toDouble(),
+      snappedLat: (json['snapped_lat'] as num).toDouble(),
+      snappedLon: (json['snapped_lon'] as num).toDouble(),
+      constraintAlerts: (json['constraint_alerts'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+    );
+  }
+}
+
+class DerivedInstructionDto {
+  final String kind;
+  final double distanceToNextM;
+  final String? streetName;
+
+  DerivedInstructionDto({
+    required this.kind,
+    required this.distanceToNextM,
+    this.streetName,
+  });
+
+  factory DerivedInstructionDto.fromJson(Map<String, dynamic> json) {
+    return DerivedInstructionDto(
+      kind: json['kind'] as String,
+      distanceToNextM: (json['distance_to_next_m'] as num).toDouble(),
+      streetName: json['street_name'] as String?,
+    );
+  }
+}
+
 class NavCue {
   final String id;
   final String instruction;

--- a/native/nav_core/Cargo.toml
+++ b/native/nav_core/Cargo.toml
@@ -21,6 +21,7 @@ crc32fast = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 async-trait = "0.1"
 sha2 = "0.10"
+# Aliased so source code uses `device_comm::*` for brevity; the actual crate is `nav_protocol`.
 device_comm = { package = "nav_protocol", path = "../nav_protocol" }
 nav_ir = { path = "../nav_ir" }
 nav_engine = { path = "../nav_engine" }

--- a/native/nav_core/src/api/helpers.rs
+++ b/native/nav_core/src/api/helpers.rs
@@ -96,6 +96,15 @@ where
     Ok(serde_json::to_string(&result)?)
 }
 
+/// Helper for asynchronous operations that return a typed value (no JSON serialization)
+pub fn query_async<T, F, Fut>(operation: F) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    block_on(operation())
+}
+
 /// Helper for asynchronous operations that return nothing
 ///
 /// # Example

--- a/native/nav_core/src/api/navigation/navigation.rs
+++ b/native/nav_core/src/api/navigation/navigation.rs
@@ -31,13 +31,13 @@ pub fn start_navigation_session(
     })
 }
 
-/// Update current position during navigation. Returns navigation state as JSON.
+/// Update current position during navigation. Returns typed navigation state.
 pub fn update_navigation_position(
     session_id: String,
     latitude: f64,
     longitude: f64,
-) -> Result<String> {
-    query_json_async(|| async {
+) -> Result<NavigationStateDto> {
+    query_async(|| async {
         let position = Position::new(latitude, longitude).map_err(|e| anyhow::anyhow!(e))?;
         let session_uuid = uuid::Uuid::parse_str(&session_id)?;
 
@@ -52,7 +52,7 @@ pub fn update_navigation_position(
 }
 
 /// Get the latest navigation state for a session without updating position.
-pub fn get_navigation_state(session_id: String) -> Result<Option<String>> {
+pub fn get_navigation_state(session_id: String) -> Result<Option<NavigationStateDto>> {
     block_on(async {
         let session_uuid = uuid::Uuid::parse_str(&session_id)?;
         let session = get_container()
@@ -71,9 +71,7 @@ pub fn get_navigation_state(session_id: String) -> Result<Option<String>> {
                     s.distance_traveled_m,
                 );
                 let nav_state = engine.update_position(coord, None);
-                Ok(Some(serde_json::to_string(&navigation_state_to_dto(
-                    nav_state,
-                ))?))
+                Ok(Some(navigation_state_to_dto(nav_state)))
             }
             _ => Ok(None),
         }

--- a/native/nav_e_ffi/src/lib.rs
+++ b/native/nav_e_ffi/src/lib.rs
@@ -8,6 +8,10 @@ use anyhow::Result;
 use flutter_rust_bridge::frb;
 use std::sync::Arc;
 
+// Re-export DTOs so FRB generates typed Dart classes for them.
+pub use nav_core::api::dto::DerivedInstructionDto;
+pub use nav_core::api::dto::NavigationStateDto;
+
 // ============================================================================
 // Initialization API
 // ============================================================================
@@ -49,20 +53,20 @@ pub fn start_navigation_session(
     nav_core::api::start_navigation_session(waypoints, current_position)
 }
 
-/// Update current position during navigation. Returns `NavigationStateDto` as JSON.
+/// Update current position during navigation. Returns typed navigation state.
 #[frb]
 pub fn update_navigation_position(
     session_id: String,
     latitude: f64,
     longitude: f64,
-) -> Result<String> {
+) -> Result<NavigationStateDto> {
     nav_core::api::update_navigation_position(session_id, latitude, longitude)
 }
 
 /// Get the latest navigation state for an active session without moving.
-/// Returns `NavigationStateDto` JSON or null if session not found.
+/// Returns typed navigation state or null if session not found.
 #[frb]
-pub fn get_navigation_state(session_id: String) -> Result<Option<String>> {
+pub fn get_navigation_state(session_id: String) -> Result<Option<NavigationStateDto>> {
     nav_core::api::get_navigation_state(session_id)
 }
 

--- a/scripts/validate_release.sh
+++ b/scripts/validate_release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Usage: validate_release.sh <version>
+# Validates pre-conditions for a release build. Exits 1 on any failure.
+set -euo pipefail
+
+VERSION="${1:?Usage: validate_release.sh <version>}"
+
+# Ensure we're on main and clean
+git fetch origin main --tags
+[[ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]] || (echo "❌ Not on main branch" && exit 1)
+test -z "$(git status --porcelain)" || (echo "❌ Workspace not clean" && exit 1)
+
+# Validate version format
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "❌ Invalid version format. Use semantic versioning (e.g., 1.2.3)"
+  exit 1
+fi
+
+# Check if tag already exists
+if git tag | grep -q "^v${VERSION}$"; then
+  echo "❌ Tag v${VERSION} already exists"
+  exit 1
+fi
+
+# Validate pubspec version matches input
+PUBSPEC_VERSION=$(grep -E '^version:' pubspec.yaml | awk '{print $2}' | cut -d+ -f1)
+if [ "$PUBSPEC_VERSION" != "$VERSION" ]; then
+  echo "❌ pubspec.yaml version ($PUBSPEC_VERSION) doesn't match input ($VERSION)"
+  echo "💡 Please update pubspec.yaml first"
+  exit 1
+fi
+
+echo "✅ All validation checks passed"


### PR DESCRIPTION
- Add explanatory comment for device_comm Cargo alias (resolves to nav_protocol)
- Extract release validation into scripts/validate_release.sh; release.yml now delegates to it instead of inlining 25 lines of bash
- Expose NavigationStateDto and DerivedInstructionDto as typed FRB structs; update_navigation_position and get_navigation_state return typed values instead of JSON strings; nav_bloc.dart uses direct field access instead of jsonDecode

NOTE: requires `make codegen` after merge to regenerate lib/bridge/ bindings.

## Summary
What does this change?

## Type
- [ ] feat
- [ ] fix
- [ ] chore/refactor
- [ ] docs
- [ ] ci/build
- [ ] test

## Checklist
- [ ] PR title follows Conventional Commits
- [ ] `dart analyze` passes
- [ ] Tests added/updated
- [ ] Builds locally (`flutter build apk --debug`)

> [!NOTE]
> FFI bindings are auto-generated on merge to main. Don't commit `lib/bridge/generated/` files.
